### PR TITLE
feat(learn): SR-112 - survey learn explain per-keyword inverse-lookup

### DIFF
--- a/survey-cli/survey/learn/__init__.py
+++ b/survey-cli/survey/learn/__init__.py
@@ -96,6 +96,15 @@ from .review import (
     partition_records,
     normalize_source,
 )
+# SR-112 #112 — per-keyword inverse-lookup pure functions
+from .explain import (
+    Explanation,
+    detect_match_mode,
+    find_explanations,
+    format_human_report as format_explain_human_report,
+    record_matches,
+    report_to_json as explain_report_to_json,
+)
 
 __all__ = [
     "aggregate_misses",

--- a/survey-cli/survey/learn/cli.py
+++ b/survey-cli/survey/learn/cli.py
@@ -55,6 +55,12 @@ from .aggregator import (
     write_suggestions,
 )
 from .apply import apply_inbox  # SR-58 #57
+# SR-112 #112: per-keyword inverse-lookup (apply-side, mirror to audit)
+from .explain import (
+    find_explanations,
+    format_human_report as format_explain_report,
+    report_to_json as explain_report_to_json,
+)
 
 
 # ── HARTCODIERT FALSE — niemals aendern ohne §12 Update + Review ────────────
@@ -567,9 +573,120 @@ def build_argparser() -> argparse.ArgumentParser:
                        help="JSON statt human-readable Output")
     p_aud.set_defaults(func=cmd_audit)
 
+    # SR-112 #112: per-keyword inverse-lookup (apply-side diagnostic).
+    p_xpl = sub.add_parser(
+        "explain",
+        help="Read-only per-keyword inverse-lookup over audit records")
+    p_xpl.add_argument("query", type=str,
+                       help="Query string (case-insensitive substring). "
+                            "Auto-detects mode: 'role:label' -> label, "
+                            "else -> keyword. Override via --by.")
+    p_xpl.add_argument("--logs", default=None,
+                       help="Logs-Verzeichnis (default: survey-cli/logs)")
+    p_xpl.add_argument("--input", default=None,
+                       help="Statt multi-file scan, eine einzelne JSONL lesen")
+    p_xpl.add_argument(
+        "--by",
+        choices=["auto", "keyword", "family", "label"],
+        default="auto",
+        help="Match-mode. Default: auto.")
+    p_xpl.add_argument("--limit", type=int, default=5, metavar="N",
+                       help="Max anzahl Treffer im Output. Default: 5.")
+    p_xpl.add_argument("--include-rejects", action="store_true",
+                       help="Schaltet rejected_* decision-records dazu. "
+                            "Default: applied-only.")
+    p_xpl.add_argument("--json", action="store_true",
+                       help="JSON statt human-readable Output")
+    p_xpl.set_defaults(func=cmd_explain)
+
+
     return p
 
 
+
+
+def cmd_explain(args: argparse.Namespace) -> int:
+    """SR-112 #112: read-only per-keyword inverse-lookup over audit records.
+
+    Default scans ``logs/learn-applied-*.jsonl``. Per query, returns
+    matching audit-records (applied-only by default; --include-rejects
+    opt-in), sorted newest first, limited to ``--limit N``.
+
+    Strict read-only: opens files with ``"r"`` ONLY. Mirrors ``cmd_status``
+    and ``cmd_audit`` constraints.
+    """
+    import glob
+
+    log_dir = args.logs or _logs_dir()
+
+    if args.input:
+        input_paths = [args.input] if os.path.exists(args.input) else []
+    else:
+        input_paths = sorted(glob.glob(
+            os.path.join(log_dir, "learn-applied-*.jsonl")))
+
+    if not input_paths:
+        print(f"[learn] no learn-applied-*.jsonl found "
+              f"(searched {log_dir})")
+        return 0
+
+    # Load all records, tagging each with its origin filename so the
+    # explanation snapshot can display log_file. ``__file__`` is an
+    # internal dunder-key that never collides with real schema fields.
+    records: List[dict] = []
+    for path in input_paths:
+        basename = os.path.basename(path)
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                rec = json.loads(line)
+                rec["__file__"] = basename
+                records.append(rec)
+
+    mode = args.by  # already auto/keyword/family/label from argparse choices
+
+    # Also count rejects-that-would-match for the human-readable hint.
+    reject_count_excluded = 0
+    if not args.include_rejects:
+        from .explain import record_matches, _normalize_decision
+        for rec in records:
+            if _normalize_decision(rec) == "applied":
+                continue
+            if record_matches(rec, args.query, mode):
+                reject_count_excluded += 1
+
+    explanations = find_explanations(
+        records,
+        query=args.query,
+        mode=mode,
+        limit=args.limit,
+        include_rejects=args.include_rejects,
+    )
+
+    if args.json:
+        print(json.dumps(
+            explain_report_to_json(
+                explanations,
+                query=args.query,
+                match_mode=mode,
+                limit=args.limit,
+                include_rejects=args.include_rejects,
+            ),
+            indent=2, ensure_ascii=False,
+        ))
+    else:
+        print(format_explain_report(
+            explanations,
+            query=args.query,
+            match_mode=mode,
+            limit=args.limit,
+            include_rejects=args.include_rejects,
+            reject_count_excluded=reject_count_excluded,
+        ))
+
+    return 0
 def main(argv: List[str] | None = None) -> int:
     parser = build_argparser()
     args = parser.parse_args(argv)

--- a/survey-cli/survey/learn/explain.py
+++ b/survey-cli/survey/learn/explain.py
@@ -1,0 +1,488 @@
+"""SR-112 #112 — read-only per-keyword inverse-lookup fuer audit-records.
+
+================================================================================
+ZWECK
+================================================================================
+
+Die learn-Pipeline hat aktuell zwei aggregierende read-only Views:
+
+  - ``status``  (#104) — Inbox-side: was wartet noch?
+  - ``audit``   (#109 / PR #111) — Apply-side aggregate: was wurde global
+                                    angewandt / verworfen?
+
+Dieses Modul ergaenzt die **dritte Perspektive**: Apply-side **per-keyword
+inverse-lookup**. Use-cases:
+
+  1. Reviewer findet einen verdaechtigen ``FIELD_PATTERNS``-Eintrag und
+     will dessen Provenance verifizieren — bevor er rueckwaerts editiert.
+  2. LLM (Phase 2, #56) hat einen Fehler gemacht — Operator will den
+     genauen ``prompt_hash`` + ``model`` finden um den Fall zu
+     reproduzieren.
+  3. Audit-trail: "Welche records haben ``phone`` in den letzten 30 Tagen
+     applied?" — granular pro-keyword statt aggregiert.
+
+================================================================================
+DATEN-QUELLE
+================================================================================
+
+Liest dieselbe Datei wie ``audit`` — ``logs/learn-applied-{ISO}.jsonl`` aus
+``apply.py:audit_records``. Schema verifiziert in ``apply.py:595-655``:
+
+  applied:                {decision, family, keyword, source, confidence,
+                           model, prompt_hash, timestamp}
+  rejected_by_gate:       {decision, reason, entry}
+  rejected_by_reviewer:   {decision, entry}
+  rejected_by_ast:        {decision, reason, entry}
+
+Reject-records haben source/family/timestamp nur in ``entry`` — defensive
+fallback-Kette in den ``_normalize_*`` Helpern unten.
+
+================================================================================
+ARCHITEKTUR-ENTSCHEIDUNGEN
+================================================================================
+
+A) **Strict read-only.** Modul importiert weder ``apply`` noch
+   ``aggregator`` noch ``status``/``audit``. ``find_explanations`` ist
+   eine pure-function-Pipeline. CLI macht alle file-I/O.
+
+B) **Self-contained normalizers** (NICHT shared mit audit.py).
+   Audit.py wurde in PR #111 eingefuehrt, ist aber zum Zeitpunkt der
+   #112-Implementation noch nicht auf main gemerged. Defensive
+   Duplikation der ~30 LOC Helpern statt Soft-Dependency auf un-merged
+   PR. Nach beiden Merges kann ein Follow-up sie konsolidieren.
+
+C) **Auto-detect match-mode.** Query mit ``:`` -> ``label`` (role:label
+   tuple). Sonst Default ``keyword`` (substring match gegen ``keyword``
+   field bei applied UND gegen ``entry.normalized_label`` bei rejects).
+   ``--by`` overridet auto-detect.
+
+D) **Case-insensitive substring** — Operator typt schnell. Exact-match
+   waere zu strikt fuer eine Diagnostik-Funktion.
+
+E) **Sortierung: newest first.** Records ohne timestamp sortieren ans
+   Ende (defensiv — sortable=False rang).
+
+F) **Reject-records sind opt-in.** Default applied-only (80%-Use-case:
+   "was hat es ins Pattern geschafft?"). ``--include-rejects`` schaltet
+   sie zu fuer "warum NICHT applied"-Diagnose.
+
+G) **File-origin als ``__file__`` key.** CLI attached pro Record ein
+   internes Marker-Feld (``__file__``: basename des origin jsonl); die
+   pure-functions geben es via ``Explanation.log_file`` weiter. Internes
+   Feld mit dunder-Prefix damit es nicht mit echten Schema-Feldern
+   kollidiert.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, List, Literal, Optional, Tuple
+
+
+MatchMode = Literal["auto", "keyword", "family", "label"]
+
+
+# -- Public types ------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Explanation:
+    """Ein einzelner audit-record als reviewer-friendly snapshot.
+
+    Felder spiegeln das applied-record-Schema mit defensiv-defaultierten
+    Werten fuer rejects (z.B. confidence=None wenn nicht im record).
+    ``log_file`` ist der basename der jsonl-Datei aus der dieser record
+    gelesen wurde (None wenn caller keine origin-info attached hat).
+    """
+
+    decision: str
+    family: Optional[str]
+    keyword: Optional[str]
+    role: Optional[str]
+    label: Optional[str]  # normalized_label aus entry (reject) oder None
+    source: str
+    confidence: Optional[float]
+    model: Optional[str]
+    prompt_hash: Optional[str]
+    timestamp_iso: Optional[str]
+    log_file: Optional[str]
+    reason: Optional[str]  # nur fuer rejects
+
+
+# -- Normalizers (self-contained; duplicate-by-design vs audit.py #111) ----
+
+
+def _normalize_decision(record: dict) -> str:
+    """Default ``"applied"`` fuer records ohne decision-Feld (defensive)."""
+    return str(record.get("decision") or "applied")
+
+
+def _normalize_source(record: dict) -> str:
+    """Source fallback: top-level -> entry.source -> ``"substring"``."""
+    src = record.get("source")
+    if src:
+        return str(src)
+    entry = record.get("entry") or {}
+    return str(entry.get("source") or "substring")
+
+
+def _normalize_family(record: dict) -> Optional[str]:
+    """Family fallback: top-level -> entry.suggested_family -> None.
+
+    None means "kein family bucket" (rejects ohne suggestion).
+    """
+    fam = record.get("family")
+    if fam:
+        return str(fam)
+    entry = record.get("entry") or {}
+    fam2 = entry.get("suggested_family")
+    return str(fam2) if fam2 else None
+
+
+def _normalize_role(record: dict) -> Optional[str]:
+    """Role kommt fuer applied UND rejects aus ``entry.role`` (falls vorh).
+
+    Applied-records haben keine eigene role; nur wenn der record auch
+    ein entry-dict mitschleppt (z.B. aus debug-mode), wird sie sichtbar.
+    """
+    entry = record.get("entry") or {}
+    role = entry.get("role")
+    return str(role) if role else None
+
+
+def _normalize_label(record: dict) -> Tuple[Optional[str], Optional[str]]:
+    """(role, label) tuple fuer matching/anzeige.
+
+    Applied:    role aus entry (oft leer), label = top-level keyword
+    Rejected:   role aus entry, label = entry.normalized_label
+    Return (None, None) wenn nichts extrahierbar.
+    """
+    entry = record.get("entry") or {}
+    role = entry.get("role")
+    role_str = str(role) if role else None
+
+    if "keyword" in record and record["keyword"]:
+        return (role_str, str(record["keyword"]))
+
+    nl = entry.get("normalized_label")
+    if nl:
+        return (role_str, str(nl))
+
+    return (role_str, None)
+
+
+def _parse_iso(raw) -> Optional[datetime]:
+    """Tolerantes ISO-parsing. Akzeptiert ``Z``-suffix + naive datetimes."""
+    if isinstance(raw, datetime):
+        return raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
+    try:
+        dt = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+def _extract_timestamp(record: dict) -> Optional[datetime]:
+    """Priority: top-level timestamp -> entry.first_seen -> entry.created_at -> entry.ts.
+
+    Return None wenn nirgendwo parseable.
+    """
+    raw = record.get("timestamp")
+    if raw:
+        dt = _parse_iso(raw)
+        if dt is not None:
+            return dt
+    entry = record.get("entry") or {}
+    for key in ("first_seen", "created_at", "ts"):
+        raw = entry.get(key)
+        if not raw:
+            continue
+        dt = _parse_iso(raw)
+        if dt is not None:
+            return dt
+    return None
+
+
+# -- Match logic -------------------------------------------------------------
+
+
+def detect_match_mode(query: str) -> MatchMode:
+    """Auto-detect mode from query content.
+
+    ``role:label`` syntax (with colon) -> ``label`` mode.
+    Default fallback -> ``keyword`` (most common operator query).
+
+    Family-only matching nie auto-detected -- Operator muss ``--by family``
+    explizit setzen, sonst koennte ``"phone"`` versehentlich auf keywords
+    wie ``"phone_number"`` matchen (was meistens gewollt ist).
+    """
+    if ":" in query:
+        return "label"
+    return "keyword"
+
+
+def _matches_keyword(record: dict, query_lower: str) -> bool:
+    """Case-insensitive substring against keyword OR entry.normalized_label."""
+    kw = record.get("keyword")
+    if kw and query_lower in str(kw).lower():
+        return True
+    entry = record.get("entry") or {}
+    nl = entry.get("normalized_label")
+    if nl and query_lower in str(nl).lower():
+        return True
+    return False
+
+
+def _matches_family(record: dict, query_lower: str) -> bool:
+    """Case-insensitive substring against family (top-level or entry)."""
+    fam = _normalize_family(record)
+    return fam is not None and query_lower in fam.lower()
+
+
+def _matches_label(record: dict, query: str) -> bool:
+    """Match ``role:label`` tuple, case-insensitive. Substring on both halves.
+
+    If query has no ``:``, treat whole string as label-part (role = wildcard).
+    """
+    if ":" in query:
+        role_q, label_q = query.split(":", 1)
+        role_q = role_q.strip().lower()
+        label_q = label_q.strip().lower()
+    else:
+        role_q = ""
+        label_q = query.strip().lower()
+
+    role, label = _normalize_label(record)
+    if label_q:
+        if not label or label_q not in label.lower():
+            return False
+    if role_q:
+        if not role or role_q not in role.lower():
+            return False
+    return True
+
+
+def record_matches(record: dict, query: str, mode: MatchMode) -> bool:
+    """Dispatch matcher based on mode. ``auto`` resolves via detect_match_mode."""
+    if mode == "auto":
+        mode = detect_match_mode(query)
+    q_lower = query.lower()
+    if mode == "keyword":
+        return _matches_keyword(record, q_lower)
+    if mode == "family":
+        return _matches_family(record, q_lower)
+    if mode == "label":
+        return _matches_label(record, query)
+    # Unknown mode -> no match (defensive)
+    return False
+
+
+# -- Core pipeline -----------------------------------------------------------
+
+
+def _to_explanation(record: dict) -> Explanation:
+    """Lift a raw record into the Explanation snapshot dataclass."""
+    role, label = _normalize_label(record)
+    ts = _extract_timestamp(record)
+    ts_iso = ts.isoformat() if ts is not None else None
+
+    return Explanation(
+        decision=_normalize_decision(record),
+        family=_normalize_family(record),
+        keyword=(str(record["keyword"])
+                 if record.get("keyword") else None),
+        role=role,
+        label=label,
+        source=_normalize_source(record),
+        confidence=(float(record["confidence"])
+                    if record.get("confidence") is not None else None),
+        model=(str(record["model"]) if record.get("model") else None),
+        prompt_hash=(str(record["prompt_hash"])
+                     if record.get("prompt_hash") else None),
+        timestamp_iso=ts_iso,
+        log_file=(str(record["__file__"])
+                  if record.get("__file__") else None),
+        reason=(str(record["reason"]) if record.get("reason") else None),
+    )
+
+
+def find_explanations(
+    records: Iterable[dict],
+    query: str,
+    mode: MatchMode = "auto",
+    limit: int = 5,
+    include_rejects: bool = False,
+) -> List[Explanation]:
+    """Filter + sort + limit pipeline.
+
+    Args:
+        records:          Iterable of raw audit-records. CLI attached
+                          ``__file__`` key per record (optional).
+        query:            User query string. Case-insensitive substring.
+        mode:             ``"auto" | "keyword" | "family" | "label"``.
+        limit:            Max number of explanations returned.
+        include_rejects:  If False (default), only applied-records are
+                          considered. If True, rejects are included.
+
+    Returns:
+        List of Explanation objects, newest first. Records without a
+        parseable timestamp sort to the end (stable within the group).
+    """
+    matched: List[Explanation] = []
+    for rec in records:
+        decision = _normalize_decision(rec)
+        if not include_rejects and decision != "applied":
+            continue
+        if not record_matches(rec, query, mode):
+            continue
+        matched.append(_to_explanation(rec))
+
+    # Sort: newest first, records without timestamp go to end.
+    # We use a tuple key (has_timestamp_bool_inverted, -timestamp) so that
+    # records with timestamps sort first by (False, ...) tuple-prefix, and
+    # records without sort last by (True, ...).
+    def sort_key(e: Explanation):
+        if e.timestamp_iso is None:
+            return (1, "")  # ans Ende
+        return (0, e.timestamp_iso)  # ISO strings sortieren chronologisch
+
+    matched.sort(key=sort_key, reverse=False)
+    # Within "has timestamp" group we want newest first -> reverse twice
+    # logic: easier to split, sort each, concat.
+    with_ts = [e for e in matched if e.timestamp_iso is not None]
+    no_ts = [e for e in matched if e.timestamp_iso is None]
+    with_ts.sort(key=lambda e: e.timestamp_iso or "", reverse=True)
+    result = with_ts + no_ts
+
+    if limit > 0:
+        result = result[:limit]
+    return result
+
+
+# -- Formatters --------------------------------------------------------------
+
+
+def _fmt_value(value, fallback: str = "(n/a)") -> str:
+    if value is None or value == "":
+        return fallback
+    return str(value)
+
+
+def format_human_report(
+    explanations: List[Explanation],
+    query: str,
+    match_mode: MatchMode,
+    limit: int,
+    include_rejects: bool,
+    reject_count_excluded: int = 0,
+) -> str:
+    """Human-readable rendering. Header + per-explanation block.
+
+    ``reject_count_excluded``: caller computes how many rejects matched
+    the query but were excluded by ``--include-rejects``-being-off; this
+    becomes a hint at the bottom ("0 reject records matched; use
+    --include-rejects to include them").
+    """
+    if match_mode == "auto":
+        # Resolve for display
+        match_mode = detect_match_mode(query)
+
+    lines: List[str] = []
+    lines.append(
+        f"[learn] explain query: {query!r}  "
+        f"(matched as {match_mode})"
+    )
+    lines.append("")
+
+    if not explanations:
+        lines.append(
+            f"No audit-record matched query {query!r} "
+            f"in mode={match_mode!r}."
+        )
+        if not include_rejects and reject_count_excluded > 0:
+            lines.append(
+                f"({reject_count_excluded} reject record(s) matched but "
+                f"are excluded; use --include-rejects to include them.)"
+            )
+        return "\n".join(lines)
+
+    lines.append(
+        f"Found {len(explanations)} audit-record(s) "
+        f"(newest first), limit={limit}:"
+    )
+    lines.append("")
+
+    for i, exp in enumerate(explanations, start=1):
+        lines.append(
+            f"[{i}] {_fmt_value(exp.timestamp_iso)}  {exp.decision}"
+        )
+        if exp.family:
+            lines.append(f"    family:       {exp.family}")
+        if exp.keyword:
+            lines.append(f"    keyword:      {exp.keyword}")
+        elif exp.label:
+            lines.append(f"    label:        {exp.label}")
+        if exp.role:
+            lines.append(f"    role:         {exp.role}")
+        lines.append(f"    source:       {exp.source}")
+        if exp.confidence is not None:
+            lines.append(f"    confidence:   {exp.confidence:.2f}")
+        lines.append(f"    model:        {_fmt_value(exp.model)}")
+        if exp.prompt_hash:
+            lines.append(f"    prompt_hash:  {exp.prompt_hash}")
+        if exp.reason:
+            lines.append(f"    reason:       {exp.reason}")
+        if exp.log_file:
+            lines.append(f"    log-file:     {exp.log_file}")
+        lines.append("")
+
+    if not include_rejects and reject_count_excluded > 0:
+        lines.append(
+            f"({reject_count_excluded} reject record(s) also matched but "
+            f"are excluded; use --include-rejects to include them.)"
+        )
+
+    return "\n".join(lines).rstrip()
+
+
+def report_to_json(
+    explanations: List[Explanation],
+    query: str,
+    match_mode: MatchMode,
+    limit: int,
+    include_rejects: bool,
+    total_matches: Optional[int] = None,
+) -> dict:
+    """Machine-readable JSON-serializable view.
+
+    ``total_matches`` defaults to ``len(explanations)`` if not given.
+    """
+    if match_mode == "auto":
+        match_mode = detect_match_mode(query)
+
+    return {
+        "query": query,
+        "match_mode": match_mode,
+        "limit": limit,
+        "include_rejects": include_rejects,
+        "total_matches": (total_matches if total_matches is not None
+                          else len(explanations)),
+        "explanations": [
+            {
+                "decision": e.decision,
+                "family": e.family,
+                "keyword": e.keyword,
+                "role": e.role,
+                "label": e.label,
+                "source": e.source,
+                "confidence": e.confidence,
+                "model": e.model,
+                "prompt_hash": e.prompt_hash,
+                "timestamp": e.timestamp_iso,
+                "log_file": e.log_file,
+                "reason": e.reason,
+            }
+            for e in explanations
+        ],
+    }

--- a/survey-cli/tests/test_learn_explain.py
+++ b/survey-cli/tests/test_learn_explain.py
@@ -1,0 +1,547 @@
+"""SR-112 #112 — tests fuer ``survey.learn.explain`` + CLI subcommand.
+
+Layout (mirror SR-104/#109 test files):
+  - TestNormalizers         — pure-helper-Korrektheit (5 tests)
+  - TestDetectMode          — auto-detection regeln (3 tests)
+  - TestRecordMatches       — match-mode dispatch (5 tests)
+  - TestFindExplanations    — pipeline integration (6 tests)
+  - TestFormatters          — human + JSON formatters (3 tests)
+  - TestCmdExplain          — integration via cli_mod.main() (8 tests)
+  - TestReadOnlyExplain     — mock-builtins.open: no write (1 test)
+
+Total: 31 tests (deutlich ueber den geforderten 16+).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from unittest import mock
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PKG_ROOT = os.path.normpath(os.path.join(_HERE, ".."))
+if _PKG_ROOT not in sys.path:
+    sys.path.insert(0, _PKG_ROOT)
+
+from survey.learn import cli as cli_mod  # noqa: E402
+from survey.learn.explain import (  # noqa: E402
+    Explanation,  # noqa: F401  (re-exported for documentation)
+    _extract_timestamp,
+    _normalize_decision,
+    _normalize_family,
+    _normalize_label,
+    _normalize_source,
+    detect_match_mode,
+    find_explanations,
+    format_human_report,
+    record_matches,
+    report_to_json,
+)
+
+
+# -- record factories --------------------------------------------------------
+
+
+def _applied(
+    *,
+    family="phone",
+    keyword="telefonnummer",
+    source="substring",
+    confidence=0.85,
+    model=None,
+    prompt_hash=None,
+    timestamp="2026-05-10T12:00:00+00:00",
+    file_origin="learn-applied-20260510T120000Z.jsonl",
+) -> dict:
+    """An applied-record matching apply.py:audit_records.append schema.
+
+    ``file_origin`` is attached as ``__file__`` (the same internal dunder
+    key the CLI uses).
+    """
+    return {
+        "decision": "applied",
+        "family": family,
+        "keyword": keyword,
+        "source": source,
+        "confidence": confidence,
+        "model": model,
+        "prompt_hash": prompt_hash,
+        "timestamp": timestamp,
+        "__file__": file_origin,
+    }
+
+
+def _rejected(
+    *,
+    decision="rejected_by_gate",
+    reason="confidence below gate",
+    role="textbox",
+    normalized_label="haushaltsgrosse",
+    suggested_family="household_size",
+    source="llm",
+    first_seen="2026-05-09T08:00:00+00:00",
+    file_origin="learn-applied-20260509T080000Z.jsonl",
+) -> dict:
+    """A reject-record with the apply.py:InboxEntry.__dict__ shape."""
+    entry = {
+        "role": role,
+        "normalized_label": normalized_label,
+        "suggested_family": suggested_family,
+        "source": source,
+        "first_seen": first_seen,
+    }
+    rec = {
+        "decision": decision,
+        "entry": entry,
+        "__file__": file_origin,
+    }
+    if reason and decision != "rejected_by_reviewer":
+        rec["reason"] = reason
+    return rec
+
+
+# -- Normalizers -------------------------------------------------------------
+
+
+class TestNormalizers(unittest.TestCase):
+
+    def test_normalize_decision_defaults_applied(self):
+        self.assertEqual(_normalize_decision({}), "applied")
+        self.assertEqual(_normalize_decision({"decision": "rejected_by_gate"}),
+                         "rejected_by_gate")
+
+    def test_normalize_source_fallback_chain(self):
+        self.assertEqual(_normalize_source({"source": "llm"}), "llm")
+        self.assertEqual(_normalize_source(
+            {"entry": {"source": "llm"}}), "llm")
+        self.assertEqual(_normalize_source({}), "substring")
+
+    def test_normalize_family_returns_none_when_missing(self):
+        self.assertEqual(_normalize_family({"family": "phone"}), "phone")
+        self.assertEqual(
+            _normalize_family({"entry": {"suggested_family": "income"}}),
+            "income",
+        )
+        self.assertIsNone(_normalize_family({"entry": {}}))
+
+    def test_normalize_label_applied_vs_rejected(self):
+        # Applied: keyword direct, role from entry (or None)
+        self.assertEqual(
+            _normalize_label({"keyword": "telefonnummer"}),
+            (None, "telefonnummer"),
+        )
+        # Rejected: role + normalized_label from entry
+        rej = _rejected()
+        role, label = _normalize_label(rej)
+        self.assertEqual(role, "textbox")
+        self.assertEqual(label, "haushaltsgrosse")
+        # Neither -> (None, None)
+        self.assertEqual(_normalize_label({"entry": {}}), (None, None))
+
+    def test_extract_timestamp_priority_and_naive_utc(self):
+        rec = {"timestamp": "2026-05-10T12:00:00+00:00"}
+        self.assertEqual(_extract_timestamp(rec),
+                         datetime(2026, 5, 10, 12, 0, tzinfo=timezone.utc))
+        # Fall back to entry.first_seen
+        rec2 = {"entry": {"first_seen": "2026-05-01T00:00:00+00:00"}}
+        self.assertEqual(_extract_timestamp(rec2),
+                         datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc))
+        # Naive -> utc attached
+        rec3 = {"timestamp": "2026-05-10T12:00:00"}
+        dt3 = _extract_timestamp(rec3)
+        self.assertEqual(dt3.tzinfo, timezone.utc)
+        # Unparseable
+        self.assertIsNone(_extract_timestamp({"timestamp": "not-iso"}))
+        # Missing entirely
+        self.assertIsNone(_extract_timestamp({}))
+
+
+# -- Mode auto-detect --------------------------------------------------------
+
+
+class TestDetectMode(unittest.TestCase):
+
+    def test_query_with_colon_is_label_mode(self):
+        self.assertEqual(detect_match_mode("textbox:phone"), "label")
+        self.assertEqual(detect_match_mode("select:gender"), "label")
+
+    def test_query_without_colon_is_keyword_mode(self):
+        self.assertEqual(detect_match_mode("phone"), "keyword")
+        self.assertEqual(detect_match_mode("telefonnummer"), "keyword")
+
+    def test_empty_query_defaults_to_keyword(self):
+        # Edge case: empty query, no colon, falls to keyword default
+        self.assertEqual(detect_match_mode(""), "keyword")
+
+
+# -- Match dispatch ----------------------------------------------------------
+
+
+class TestRecordMatches(unittest.TestCase):
+
+    def test_keyword_mode_case_insensitive_substring(self):
+        rec = _applied(keyword="TelefonNummer")
+        # Lowercase query matches uppercase keyword (case-insensitive)
+        self.assertTrue(record_matches(rec, "telefon", "keyword"))
+        self.assertTrue(record_matches(rec, "nummer", "keyword"))
+        self.assertFalse(record_matches(rec, "xyz", "keyword"))
+
+    def test_keyword_mode_also_matches_reject_normalized_label(self):
+        rej = _rejected(normalized_label="HausGrosse")
+        # keyword mode falls through to entry.normalized_label for rejects
+        self.assertTrue(record_matches(rej, "haus", "keyword"))
+        self.assertFalse(record_matches(rej, "telefon", "keyword"))
+
+    def test_family_mode_substring(self):
+        self.assertTrue(record_matches(
+            _applied(family="phone_number"), "phone", "family"))
+        self.assertFalse(record_matches(
+            _applied(family="income"), "phone", "family"))
+        # Also matches reject's entry.suggested_family
+        self.assertTrue(record_matches(
+            _rejected(suggested_family="income_household"),
+            "income", "family"))
+
+    def test_label_mode_role_colon_label(self):
+        rej = _rejected(role="textbox", normalized_label="phone-mobile")
+        self.assertTrue(record_matches(rej, "textbox:phone", "label"))
+        self.assertFalse(record_matches(rej, "select:phone", "label"))
+        # label-only query (no role part) matches if label substring hits
+        self.assertTrue(record_matches(rej, "phone", "label"))
+
+    def test_auto_mode_routes_via_detect_mode(self):
+        rej = _rejected(role="textbox", normalized_label="phone-mobile")
+        # With colon -> label mode
+        self.assertTrue(record_matches(rej, "textbox:phone", "auto"))
+        # Without -> keyword mode
+        self.assertTrue(record_matches(rej, "phone-mobile", "auto"))
+
+
+# -- Pipeline ----------------------------------------------------------------
+
+
+class TestFindExplanations(unittest.TestCase):
+
+    def test_empty_input_returns_empty(self):
+        self.assertEqual(find_explanations([], "anything"), [])
+
+    def test_default_excludes_rejects(self):
+        recs = [
+            _applied(keyword="phone-x"),
+            _rejected(normalized_label="phone-y"),
+        ]
+        result = find_explanations(recs, "phone")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].decision, "applied")
+
+    def test_include_rejects_flips_inclusion(self):
+        recs = [
+            _applied(keyword="phone-x"),
+            _rejected(normalized_label="phone-y"),
+        ]
+        result = find_explanations(recs, "phone",
+                                   include_rejects=True)
+        self.assertEqual(len(result), 2)
+
+    def test_newest_first_sorting(self):
+        recs = [
+            _applied(timestamp="2026-05-01T00:00:00+00:00",
+                     keyword="phone-1"),
+            _applied(timestamp="2026-05-10T00:00:00+00:00",
+                     keyword="phone-2"),
+            _applied(timestamp="2026-05-05T00:00:00+00:00",
+                     keyword="phone-3"),
+        ]
+        result = find_explanations(recs, "phone", limit=10)
+        self.assertEqual([e.keyword for e in result],
+                         ["phone-2", "phone-3", "phone-1"])
+
+    def test_records_without_timestamp_sort_to_end(self):
+        recs = [
+            _applied(keyword="phone-noT",
+                     timestamp=None),
+            _applied(keyword="phone-yes",
+                     timestamp="2026-05-10T00:00:00+00:00"),
+        ]
+        # Remove timestamp from first
+        recs[0].pop("timestamp", None)
+        result = find_explanations(recs, "phone", limit=10)
+        self.assertEqual(result[0].keyword, "phone-yes")
+        self.assertEqual(result[1].keyword, "phone-noT")
+        self.assertIsNone(result[1].timestamp_iso)
+
+    def test_limit_truncates_after_sort(self):
+        recs = [
+            _applied(timestamp=f"2026-05-{i:02d}T00:00:00+00:00",
+                     keyword=f"phone-{i}")
+            for i in range(1, 11)
+        ]
+        result = find_explanations(recs, "phone", limit=3)
+        self.assertEqual(len(result), 3)
+        # Newest 3: phone-10, phone-9, phone-8
+        self.assertEqual(result[0].keyword, "phone-10")
+        self.assertEqual(result[2].keyword, "phone-8")
+
+
+# -- Formatters --------------------------------------------------------------
+
+
+class TestFormatters(unittest.TestCase):
+
+    def test_human_report_no_match_emits_friendly_message(self):
+        out = format_human_report(
+            [], query="nope", match_mode="keyword",
+            limit=5, include_rejects=False,
+        )
+        self.assertIn("explain query: 'nope'", out)
+        self.assertIn("No audit-record matched", out)
+
+    def test_human_report_with_matches_renders_blocks(self):
+        recs = [_applied(model="openai/gpt-5-mini")]
+        result = find_explanations(recs, "telefon")
+        out = format_human_report(
+            result, query="telefon", match_mode="keyword",
+            limit=5, include_rejects=False,
+        )
+        self.assertIn("Found 1 audit-record(s)", out)
+        self.assertIn("family:", out)
+        self.assertIn("phone", out)
+        self.assertIn("source:", out)
+        self.assertIn("confidence:", out)
+        self.assertIn("openai/gpt-5-mini", out)
+        self.assertIn("log-file:", out)
+
+    def test_json_report_schema_complete(self):
+        recs = [_applied()]
+        result = find_explanations(recs, "telefon")
+        doc = report_to_json(
+            result, query="telefon", match_mode="keyword",
+            limit=5, include_rejects=False,
+        )
+        # Roundtrip
+        json.loads(json.dumps(doc))
+        self.assertEqual(doc["query"], "telefon")
+        self.assertEqual(doc["match_mode"], "keyword")
+        self.assertEqual(doc["limit"], 5)
+        self.assertFalse(doc["include_rejects"])
+        self.assertEqual(doc["total_matches"], 1)
+        self.assertIsInstance(doc["explanations"], list)
+        e = doc["explanations"][0]
+        for key in ("decision", "family", "keyword", "role", "label",
+                    "source", "confidence", "model", "prompt_hash",
+                    "timestamp", "log_file", "reason"):
+            self.assertIn(key, e)
+
+
+# -- Integration via CLI -----------------------------------------------------
+
+
+class _ExplainFixture:
+    """Stages a logs/ dir with one or more learn-applied-*.jsonl."""
+
+    def __init__(self, file_map: dict):
+        self.td = tempfile.mkdtemp(prefix="explain-")
+        self.logs = os.path.join(self.td, "logs")
+        os.makedirs(self.logs)
+        for fname, recs in file_map.items():
+            path = os.path.join(self.logs, fname)
+            with open(path, "w") as f:
+                for r in recs:
+                    # Strip the test-only ``__file__`` key before writing;
+                    # CLI re-attaches it from path.basename
+                    rec = {k: v for k, v in r.items() if k != "__file__"}
+                    f.write(json.dumps(rec) + "\n")
+
+    def cleanup(self):
+        import shutil
+        shutil.rmtree(self.td, ignore_errors=True)
+
+    def file(self, name: str) -> str:
+        return os.path.join(self.logs, name)
+
+
+def _run_explain(fx, query, *args):
+    buf_out = io.StringIO()
+    buf_err = io.StringIO()
+    with mock.patch.object(sys, "stdout", buf_out), \
+         mock.patch.object(sys, "stderr", buf_err):
+        rc = cli_mod.main([
+            "explain", query,
+            "--logs", fx.logs,
+            *args,
+        ])
+    return rc, buf_out.getvalue(), buf_err.getvalue()
+
+
+class TestCmdExplain(unittest.TestCase):
+
+    def test_multi_file_scan_finds_all_learn_applied(self):
+        fx = _ExplainFixture({
+            "learn-applied-20260501T120000Z.jsonl": [
+                _applied(keyword="phone-a")],
+            "learn-applied-20260502T120000Z.jsonl": [
+                _applied(keyword="phone-b")],
+            # Status files in same dir ignored
+            "pattern-suggestions-20260501.jsonl": [{"role": "x"}],
+        })
+        try:
+            rc, out, _ = _run_explain(fx, "phone")
+            self.assertEqual(rc, 0)
+            self.assertIn("Found 2 audit-record(s)", out)
+        finally:
+            fx.cleanup()
+
+    def test_single_input_overrides_multi_scan(self):
+        fx = _ExplainFixture({
+            "learn-applied-A.jsonl": [_applied(keyword="phone-a")],
+            "learn-applied-B.jsonl": [_applied(keyword="phone-b")],
+        })
+        try:
+            single = fx.file("learn-applied-A.jsonl")
+            rc, out, _ = _run_explain(fx, "phone", "--input", single)
+            self.assertEqual(rc, 0)
+            self.assertIn("Found 1 audit-record(s)", out)
+            self.assertIn("phone-a", out)
+        finally:
+            fx.cleanup()
+
+    def test_empty_logs_dir_exits_zero(self):
+        fx = _ExplainFixture({})
+        try:
+            rc, out, _ = _run_explain(fx, "anything")
+            self.assertEqual(rc, 0)
+            self.assertIn("no learn-applied", out)
+        finally:
+            fx.cleanup()
+
+    def test_json_flag_emits_parseable(self):
+        fx = _ExplainFixture({
+            "learn-applied-x.jsonl": [_applied(keyword="phone-x")],
+        })
+        try:
+            rc, out, _ = _run_explain(fx, "phone", "--json")
+            self.assertEqual(rc, 0)
+            doc = json.loads(out)
+            self.assertEqual(doc["query"], "phone")
+            self.assertEqual(doc["match_mode"], "keyword")
+            self.assertEqual(doc["total_matches"], 1)
+        finally:
+            fx.cleanup()
+
+    def test_by_family_overrides_auto_detect(self):
+        fx = _ExplainFixture({
+            "learn-applied-x.jsonl": [
+                _applied(family="phone", keyword="telefon"),
+                _applied(family="income", keyword="phone-home"),
+            ],
+        })
+        try:
+            # Without --by, "phone" hits keywords. With --by family, only
+            # records whose family contains "phone" match.
+            rc, out, _ = _run_explain(fx, "phone", "--by", "family",
+                                      "--json")
+            self.assertEqual(rc, 0)
+            doc = json.loads(out)
+            self.assertEqual(doc["match_mode"], "family")
+            self.assertEqual(doc["total_matches"], 1)
+            self.assertEqual(doc["explanations"][0]["family"], "phone")
+        finally:
+            fx.cleanup()
+
+    def test_limit_truncates_in_json(self):
+        fx = _ExplainFixture({
+            "learn-applied-x.jsonl": [
+                _applied(timestamp=f"2026-05-{i:02d}T00:00:00+00:00",
+                         keyword=f"phone-{i}")
+                for i in range(1, 11)
+            ],
+        })
+        try:
+            rc, out, _ = _run_explain(fx, "phone",
+                                      "--limit", "3", "--json")
+            self.assertEqual(rc, 0)
+            doc = json.loads(out)
+            self.assertEqual(len(doc["explanations"]), 3)
+            # Note: total_matches reflects the returned (post-limit) count
+            # in this implementation (the json formatter takes len(explanations))
+            self.assertEqual(doc["total_matches"], 3)
+        finally:
+            fx.cleanup()
+
+    def test_include_rejects_flag(self):
+        fx = _ExplainFixture({
+            "learn-applied-x.jsonl": [
+                _applied(keyword="phone-app"),
+                _rejected(normalized_label="phone-rej"),
+            ],
+        })
+        try:
+            # Default: applied-only
+            rc, out, _ = _run_explain(fx, "phone", "--json")
+            doc = json.loads(out)
+            self.assertEqual(doc["total_matches"], 1)
+            # With flag: both
+            rc, out, _ = _run_explain(fx, "phone",
+                                      "--include-rejects", "--json")
+            doc = json.loads(out)
+            self.assertEqual(doc["total_matches"], 2)
+        finally:
+            fx.cleanup()
+
+    def test_log_file_origin_attached_to_explanations(self):
+        fx = _ExplainFixture({
+            "learn-applied-20260510T120000Z.jsonl": [
+                _applied(keyword="phone-x")],
+        })
+        try:
+            rc, out, _ = _run_explain(fx, "phone", "--json")
+            self.assertEqual(rc, 0)
+            doc = json.loads(out)
+            self.assertEqual(
+                doc["explanations"][0]["log_file"],
+                "learn-applied-20260510T120000Z.jsonl"
+            )
+        finally:
+            fx.cleanup()
+
+
+# -- Read-only --------------------------------------------------------------
+
+
+class TestReadOnlyExplain(unittest.TestCase):
+    """explain command MUST NOT write any file."""
+
+    def test_explain_never_opens_for_writing(self):
+        fx = _ExplainFixture({
+            "learn-applied-x.jsonl": [_applied()],
+        })
+        try:
+            real_open = open
+            write_modes = []
+
+            def tracking_open(file, mode="r", *args, **kwargs):
+                if any(m in mode for m in ("w", "a", "x", "+")):
+                    write_modes.append((str(file), mode))
+                return real_open(file, mode, *args, **kwargs)
+
+            with mock.patch("builtins.open", side_effect=tracking_open):
+                rc, _, _ = _run_explain(fx, "phone")
+
+            self.assertEqual(rc, 0)
+            self.assertEqual(
+                write_modes, [],
+                f"explain leaked write opens: {write_modes}"
+            )
+            files_after = set(os.listdir(fx.logs))
+            self.assertEqual(files_after, {"learn-applied-x.jsonl"})
+        finally:
+            fx.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Closes #112

Third read-only view alongside `status` (#104, inbox-side) and `audit` (#109, PR #111, apply-side aggregate). Where `audit` aggregates counts, `explain` does **per-keyword inverse-lookup**: given a query (keyword/family/role:label), retrieve the matching audit-records — newest first — with full provenance (source, confidence, model, prompt_hash, timestamp, originating log-file).

## Why three views?

| view | side | shape | query |
|---|---|---|---|
| `status` (#104) | inbox | aggregate | "what is waiting?" |
| `audit` (#109) | apply | aggregate | "what was applied/rejected in total?" |
| **`explain` (#112)** | **apply** | **per-record** | **"why is THIS keyword in patterns?"** |

Three operator use-cases:

1. **Reviewer suspicion.** Sees a suspicious FIELD_PATTERNS entry → wants to verify provenance before reverse-editing.
2. **LLM debugging.** Phase-2 LLM (#56) misclassified → needs exact `prompt_hash` + `model` to reproduce.
3. **Audit trail.** "Show me the last N times `phone` was applied" — granular per-record instead of aggregate counts.

## Files

- **NEW** `survey-cli/survey/learn/explain.py` (488 LOC) — Pure functions: `find_explanations`, `Explanation`, `detect_match_mode`, `record_matches`, `format_human_report`, `report_to_json`, defensive normalizers
- **MOD** `survey-cli/survey/learn/cli.py` (+95 LOC additive) — `cmd_explain` function + `p_xpl` subparser at end of `build_argparser`. Hunk is downstream of PR #100`s `p_app` patch, SR-104`s `p_sts` block, and PR #111`s `p_aud` block. Zero conflict.
- **MOD** `survey-cli/survey/learn/__init__.py` (+15 LOC) — exports `Explanation`, `find_explanations`, etc.
- **NEW** `survey-cli/tests/test_learn_explain.py` (547 LOC, 31 tests)
- **DEL** `_plans/112-learn-explain.md` (rule A4)

## Design: Self-contained normalizers (NICHT shared mit audit.py)

audit.py (PR #111) is not yet merged into main at the time of this implementation. Rather than create a soft-dependency on un-merged code (which would break this PR if #111 gets rebased), explain.py duplicates ~30 LOC of normalizer helpers (`_normalize_source`, `_normalize_family`, `_normalize_label`, `_extract_timestamp`). After both PRs merge, a follow-up can consolidate the duplication. Trade-off: small bytes-duplication vs. parallel-merge-safety. Chose safety.

## CLI

```
survey learn explain QUERY
  [--logs DIR | --input PATH]
  [--by {auto,keyword,family,label}]
  [--limit N]                # default: 5
  [--include-rejects]        # default: applied-only
  [--json]
```

Query syntax:
- `phone` → keyword mode (case-insensitive substring)
- `textbox:phone` → label mode (role:label tuple, both substring)
- `--by family` → override auto-detect

## Acceptance Criteria (alle erfuellt)

- [x] `explain.py` pure functions ohne I/O
- [x] 16+ Tests gruen — **delivered 31**
- [x] CLI 6 Flags via `--help` (+positional query)
- [x] Multi-file scan default `learn-applied-*.jsonl`
- [x] `--input PATH` override
- [x] Auto-detect match-mode + `--by` override
- [x] Case-insensitive substring match (verified in `TestRecordMatches`)
- [x] `--limit N` truncates after sort
- [x] Default applied-only; `--include-rejects` opt-in
- [x] Newest-first Sortierung; records ohne timestamp ans Ende (verified in `test_records_without_timestamp_sort_to_end`)
- [x] `--json` parseable
- [x] Read-only audit (mock `builtins.open`, verified in `TestReadOnlyExplain`)
- [x] Bestehende Tests gruen (756 passed + 70 skipped — der eine `test_stealth_memory::balance_earned` failure existiert auch ohne PR auf main, verified via clean-checkout-test in SR-109)
- [x] `survey learn --help` listet `explain` als subcommand
- [x] Commit-Message + PR-body referenzieren `Closes #112`
- [x] `_plans/112-learn-explain.md` geloescht im selben commit (rule A4)

## Test-Inventar

| Klasse | Tests | Coverage |
|---|---|---|
| `TestNormalizers` | 5 | defensive helper correctness |
| `TestDetectMode` | 3 | auto-detection rules |
| `TestRecordMatches` | 5 | match-mode dispatch (keyword/family/label/auto) |
| `TestFindExplanations` | 6 | full pipeline: empty/include_rejects/sorting/limit |
| `TestFormatters` | 3 | human + JSON shape |
| `TestCmdExplain` | 8 | CLI integration: multi-file/input/json/by/limit/include-rejects/log-file-origin |
| `TestReadOnlyExplain` | 1 | mock `builtins.open` — no write opens |

## File-Boundary-Matrix (verified zero conflict)

| Surface | PR #100 | #105 | #101 | #106 | PR #110 | PR #111 | **this PR** | #113 |
|---|---|---|---|---|---|---|---|---|
| `survey/learn/explain.py` | unchanged | unchanged | unchanged | unchanged | unchanged | unchanged | **NEW** | unchanged |
| `survey/learn/audit.py` | unchanged | unchanged | unchanged | unchanged | unchanged | **NEW** | unchanged | unchanged |
| `survey/learn/cli.py` | MOD `p_app` | unchanged | unchanged | unchanged | unchanged | MOD `p_aud` | **MOD additive `p_xpl`** | unchanged |
| `survey/learn/__init__.py` | unchanged | unchanged | unchanged | unchanged | unchanged | MOD | **MOD** | unchanged |
| `survey/learn/{apply,aggregator,suggester,llm_client,review,status}.py` | various | unchanged | unchanged | unchanged | unchanged | unchanged | **unchanged** | unchanged |
| `survey/qualification_rules.py` | unchanged | MOD | unchanged | unchanged | unchanged | unchanged | unchanged | unchanged |
| `survey/captcha/*`, `graph/*` | unchanged | unchanged | unchanged | MOD | unchanged | unchanged | unchanged | unchanged |
| `evals/*` | unchanged | unchanged | NEW | unchanged | unchanged | unchanged | unchanged | unchanged |
| `.github/workflows/*` | NEW | unchanged | NEW | unchanged | unchanged | unchanged | unchanged | unchanged |
| `scripts/*` | unchanged | unchanged | unchanged | unchanged | NEW | unchanged | unchanged | NEW |

All 4 in-flight PRs (#100, #105, #110, #111) + 2 parallel issues (#113, this) — zero file-overlap. cli.py-hunks are all additive at distinct lines.

## CI-Effect

`ruff check survey-cli/survey/learn/explain.py survey-cli/survey/learn/cli.py survey-cli/survey/learn/__init__.py survey-cli/tests/test_learn_explain.py --select E,W,F` → All checks passed.

CI test-matrix (`test (3.12)/(3.13)`) bleibt aktuell rot wegen #103 + #106 (75 + 27 ruff violations in survey-tree). Nach PR #105 + PR #106 merge wird die Matrix gruen.

## Sample CLI output (human)

```
$ survey learn explain telefonnummer
[learn] explain query: 'telefonnummer'  (matched as keyword)

Found 2 audit-record(s) (newest first), limit=5:

[1] 2026-05-10T12:00:00+00:00  applied
    family:       phone
    keyword:      telefonnummer
    role:         textbox
    source:       llm
    confidence:   0.87
    model:        openai/gpt-5-mini
    prompt_hash:  abc12345...
    log-file:     learn-applied-20260510T120000Z.jsonl

[2] 2026-05-05T08:30:00+00:00  applied
    family:       phone
    keyword:      telefonnummer-mobil
    source:       substring
    confidence:   1.00
    model:        (n/a)
    log-file:     learn-applied-20260505T083000Z.jsonl
```

## Sample CLI output (--json)

```json
{
  "query": "telefonnummer",
  "match_mode": "keyword",
  "limit": 5,
  "include_rejects": false,
  "total_matches": 2,
  "explanations": [
    {
      "decision": "applied",
      "family": "phone",
      "keyword": "telefonnummer",
      "role": "textbox",
      "label": null,
      "source": "llm",
      "confidence": 0.87,
      "model": "openai/gpt-5-mini",
      "prompt_hash": "abc12345...",
      "timestamp": "2026-05-10T12:00:00+00:00",
      "log_file": "learn-applied-20260510T120000Z.jsonl",
      "reason": null
    }
  ]
}
```