### PR TITLE
feat(scripts): SR-117 — inbox suggestion-log schema validator

### DIFF
--- a/scripts/check_inbox_log_schema.py
+++ b/scripts/check_inbox_log_schema.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+# =============================================================================
+# SR-117: Schema validator for inbox suggestion-logs
+#         (logs/pattern-suggestions-*.jsonl).
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# survey learn apply/review reads inbox records from
+# logs/pattern-suggestions-*.jsonl via InboxEntry.from_dict() (apply.py:77).
+# from_dict() silently falls back to defaults when fields are missing
+# (e.g. confidence=0.0). A corrupt record can therefore be silently applied
+# at default confidence instead of being rejected.  This script is the
+# INBOX-SCHEMA-GUARD: runs as CI-step or pre-apply hook, validates every
+# record against the InboxEntry spec, exits non-zero if drift detected.
+#
+# CONTRACT
+# --------
+# - Reads only. NEVER writes to disk, NEVER mutates input files.
+# - Default mode (no flags): print human-readable report, exit 0 always.
+# - --exit-non-zero-on-violation: exit 1 if violations > 0 (CI / alert mode).
+# - --strict: also exit 1 if warnings > 0
+#             (e.g. llm-source records missing model field).
+# - --json:  machine-parseable JSON to stdout.
+# - --quiet: suppress output, use only exit code.
+#
+# DESIGN
+# ------
+# Standalone — does NOT import `from survey.learn import ...`.
+# The scripts/ tree is sys-admin/hygiene territory and must run without the
+# survey-cli package installed.
+#
+# SCHEMA SPEC (frozen, from Issue #117 / apply.py:77-105 InboxEntry)
+# -------------------------------------------------------------------
+# Required fields (every record):
+#   role              : str, non-empty
+#   normalized_label  : str, non-empty
+#   confidence        : float,  0.0 <= x <= 1.0
+#   source            : str, one of {"substring", "llm", "manual"}
+#
+# Optional fields (if present, must be correctly typed):
+#   suggested_family  : str | null
+#   count             : int >= 0
+#   sample_labels     : list[str]
+#   matched_tokens    : list[str]
+#   model             : str | null
+#   prompt_hash       : str | null
+#
+# Cross-field WARNING (not error):
+#   source == "llm" AND model is None
+#       -> "llm-source record missing model field — pre-SR-57 legacy?"
+#
+# FILE SELECTION
+#   Glob: logs/pattern-suggestions-*.jsonl
+# =============================================================================
+"""scripts/check_inbox_log_schema.py — validate inbox suggestion-log schema.
+
+CLI:
+    python scripts/check_inbox_log_schema.py
+        [--logs DIR]                    # default: survey-cli/logs
+        [--exit-non-zero-on-violation]  # rc=1 if violations > 0
+        [--strict]                      # rc=1 if warnings > 0 too
+        [--json]                        # JSON output to stdout
+        [--quiet]                       # suppress output (exit code only)
+
+Closes #117
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+__all__ = [
+    "validate_record",
+    "iter_records",
+    "check_logs",
+    "format_human",
+    "format_json_output",
+    "main",
+]
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+DEFAULT_LOGS_DIR = "survey-cli/logs"
+INPUT_GLOB = "pattern-suggestions-*.jsonl"
+
+VALID_SOURCES = {"substring", "llm", "manual"}
+
+# ── Core validation ──────────────────────────────────────────────────────────
+
+
+def validate_record(
+    record: Dict[str, Any],
+    file_path: str,
+    line_num: int,
+) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """Validate one inbox record against the InboxEntry schema spec.
+
+    Returns (violation, warning) — each is None if not applicable.
+    violation : dict with keys file, line, record, errors
+    warning   : dict with keys file, line, record, message
+    """
+    errors: List[str] = []
+    warning: Optional[Dict[str, Any]] = None
+
+    # ── Required: role ────────────────────────────────────────────────────────
+    if "role" not in record:
+        errors.append("missing required field 'role'")
+    elif not isinstance(record["role"], str):
+        errors.append(
+            f"'role' must be str, got {type(record['role']).__name__}"
+        )
+    elif not record["role"].strip():
+        errors.append("'role' must be non-empty")
+
+    # ── Required: normalized_label ────────────────────────────────────────────
+    if "normalized_label" not in record:
+        errors.append("missing required field 'normalized_label'")
+    elif not isinstance(record["normalized_label"], str):
+        errors.append(
+            "'normalized_label' must be str, "
+            f"got {type(record['normalized_label']).__name__}"
+        )
+    elif not record["normalized_label"].strip():
+        errors.append("'normalized_label' must be non-empty")
+
+    # ── Required: confidence ─────────────────────────────────────────────────
+    if "confidence" not in record:
+        errors.append("missing required field 'confidence'")
+    elif not isinstance(record["confidence"], (int, float)):
+        errors.append(
+            "'confidence' must be numeric, "
+            f"got {type(record['confidence']).__name__}"
+        )
+    elif not (0.0 <= record["confidence"] <= 1.0):
+        errors.append(
+            f"'confidence' must be in [0.0, 1.0], got {record['confidence']}"
+        )
+
+    # ── Required: source ─────────────────────────────────────────────────────
+    source = record.get("source")
+    if "source" not in record:
+        errors.append("missing required field 'source'")
+    elif not isinstance(source, str):
+        errors.append(
+            f"'source' must be str, got {type(source).__name__}"
+        )
+    elif source not in VALID_SOURCES:
+        errors.append(
+            f"'source' must be one of {sorted(VALID_SOURCES)}, got '{source}'"
+        )
+
+    # ── Optional: suggested_family ───────────────────────────────────────────
+    if "suggested_family" in record:
+        v = record["suggested_family"]
+        if not isinstance(v, (str, type(None))):
+            errors.append(
+                "'suggested_family' must be str or null, "
+                f"got {type(v).__name__}"
+            )
+
+    # ── Optional: count ───────────────────────────────────────────────────────
+    if "count" in record:
+        v = record["count"]
+        if not isinstance(v, int):
+            errors.append(
+                f"'count' must be int, got {type(v).__name__}"
+            )
+        elif v < 0:
+            errors.append(f"'count' must be >= 0, got {v}")
+
+    # ── Optional: sample_labels ───────────────────────────────────────────────
+    if "sample_labels" in record:
+        v = record["sample_labels"]
+        if not isinstance(v, list):
+            errors.append(
+                f"'sample_labels' must be list, got {type(v).__name__}"
+            )
+        else:
+            for i, item in enumerate(v):
+                if not isinstance(item, str):
+                    errors.append(
+                        f"'sample_labels[{i}]' must be str, "
+                        f"got {type(item).__name__}"
+                    )
+
+    # ── Optional: matched_tokens ──────────────────────────────────────────────
+    if "matched_tokens" in record:
+        v = record["matched_tokens"]
+        if not isinstance(v, list):
+            errors.append(
+                f"'matched_tokens' must be list, got {type(v).__name__}"
+            )
+        else:
+            for i, item in enumerate(v):
+                if not isinstance(item, str):
+                    errors.append(
+                        f"'matched_tokens[{i}]' must be str, "
+                        f"got {type(item).__name__}"
+                    )
+
+    # ── Optional: model ───────────────────────────────────────────────────────
+    if "model" in record:
+        v = record["model"]
+        if not isinstance(v, (str, type(None))):
+            errors.append(
+                f"'model' must be str or null, got {type(v).__name__}"
+            )
+
+    # ── Optional: prompt_hash ─────────────────────────────────────────────────
+    if "prompt_hash" in record:
+        v = record["prompt_hash"]
+        if not isinstance(v, (str, type(None))):
+            errors.append(
+                f"'prompt_hash' must be str or null, got {type(v).__name__}"
+            )
+
+    # ── Cross-field warning: llm without model ────────────────────────────────
+    if (
+        isinstance(source, str)
+        and source == "llm"
+        and record.get("model") is None
+        and not errors
+    ):
+        warning = {
+            "file": file_path,
+            "line": line_num,
+            "record": record,
+            "message": (
+                "llm-source record missing model field — "
+                "pre-SR-57 legacy? (#56)"
+            ),
+        }
+
+    violation = (
+        {
+            "file": file_path,
+            "line": line_num,
+            "record": record,
+            "errors": errors,
+        }
+        if errors
+        else None
+    )
+    return violation, warning
+
+
+def iter_records(
+    file_path: str,
+) -> Tuple[Optional[Dict[str, Any]], int, Optional[str]]:
+    """Yield (record_or_None, line_num, parse_error_or_None) for each line."""
+    try:
+        with open(file_path) as fh:
+            for line_num, raw in enumerate(fh, start=1):
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line), line_num, None
+                except json.JSONDecodeError as exc:
+                    yield None, line_num, f"JSON parse error: {exc}"
+    except OSError:
+        pass  # unreadable file: skip silently
+
+
+def check_logs(
+    logs_dir: str,
+) -> Tuple[List[Dict], List[Dict], int, int]:
+    """Scan all pattern-suggestions-*.jsonl files in logs_dir.
+
+    Returns (violations, warnings, total_records, total_files).
+    """
+    violations: List[Dict] = []
+    warnings:   List[Dict] = []
+    total_records = 0
+    total_files   = 0
+
+    pattern = os.path.join(logs_dir, INPUT_GLOB)
+    for file_path in sorted(glob.glob(pattern)):
+        total_files += 1
+        for record, line_num, parse_err in iter_records(file_path):
+            if parse_err is not None:
+                violations.append(
+                    {"file": file_path, "line": line_num, "error": parse_err}
+                )
+                continue
+            total_records += 1
+            viol, warn = validate_record(record, file_path, line_num)
+            if viol:
+                violations.append(viol)
+            if warn:
+                warnings.append(warn)
+
+    return violations, warnings, total_records, total_files
+
+
+# ── Formatting ────────────────────────────────────────────────────────────────
+
+
+def format_human(
+    violations: List[Dict],
+    warnings: List[Dict],
+    total_records: int,
+    total_files: int,
+) -> str:
+    """Return a human-readable validation report."""
+    lines: List[str] = []
+
+    if not violations and not warnings:
+        lines.append(
+            f"OK  {total_records} record(s) across "
+            f"{total_files} file(s) are valid."
+        )
+        return "\n".join(lines)
+
+    header = (
+        f"Found {total_records} record(s) across {total_files} file(s) — "
+        f"{len(violations)} violation(s), {len(warnings)} warning(s)."
+    )
+    lines.append(header)
+
+    if violations:
+        lines.append("")
+        lines.append("VIOLATIONS:")
+        for v in violations:
+            lines.append(f"  {v['file']}:{v['line']}")
+            if "error" in v:
+                lines.append(f"    parse: {v['error']}")
+            else:
+                for msg in v.get("errors", []):
+                    lines.append(f"    - {msg}")
+
+    if warnings:
+        lines.append("")
+        lines.append("WARNINGS:")
+        for w in warnings:
+            lines.append(f"  {w['file']}:{w['line']}: {w['message']}")
+
+    return "\n".join(lines)
+
+
+def format_json_output(
+    violations: List[Dict],
+    warnings: List[Dict],
+    total_records: int,
+    total_files: int,
+) -> str:
+    """Return machine-parseable JSON output."""
+    return json.dumps(
+        {
+            "clean": len(violations) == 0,
+            "violations": violations,
+            "warnings": warnings,
+            "files_scanned": total_files,
+            "records_validated": total_records,
+        },
+        indent=2,
+    )
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate inbox suggestion-log schema "
+            "(pattern-suggestions-*.jsonl records)."
+        )
+    )
+    parser.add_argument(
+        "--logs",
+        default=DEFAULT_LOGS_DIR,
+        metavar="DIR",
+        help=f"Path to logs directory (default: {DEFAULT_LOGS_DIR})",
+    )
+    parser.add_argument(
+        "--exit-non-zero-on-violation",
+        action="store_true",
+        help="Exit with code 1 if violations found.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Also exit with code 1 if warnings found.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON instead of human-readable text.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress all output; use exit code only.",
+    )
+    args = parser.parse_args()
+
+    violations, warnings, total_records, total_files = check_logs(args.logs)
+
+    if not args.quiet:
+        if args.json:
+            print(
+                format_json_output(
+                    violations, warnings, total_records, total_files
+                )
+            )
+        else:
+            print(
+                format_human(
+                    violations, warnings, total_records, total_files
+                )
+            )
+
+    has_violations = len(violations) > 0
+    has_warnings   = len(warnings) > 0
+
+    if args.exit_non_zero_on_violation and has_violations:
+        return 1
+    if args.strict and (has_violations or has_warnings):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_inbox_log_schema.py
+++ b/scripts/tests/test_check_inbox_log_schema.py
@@ -1,0 +1,318 @@
+"""tests for scripts/check_inbox_log_schema.py — SR-117.
+
+Coverage (15+ tests required):
+  T01  valid minimal record (required fields only)
+  T02  valid record with all optional fields
+  T03  missing required field: role
+  T04  missing required field: normalized_label
+  T05  missing required field: confidence
+  T06  missing required field: source
+  T07  empty role string
+  T08  empty normalized_label string
+  T09  confidence below 0.0
+  T10  confidence above 1.0
+  T11  confidence exactly at boundary 0.0 and 1.0 (valid)
+  T12  invalid source enum value
+  T13  llm source without model -> warning (not violation)
+  T14  llm source WITH model -> no warning
+  T15  optional count negative -> violation
+  T16  optional sample_labels contains non-string element
+  T17  optional matched_tokens not a list
+  T18  optional model wrong type (not str/null)
+  T19  optional prompt_hash wrong type
+  T20  malformed JSON line -> parse error as violation
+  T21  empty file -> 0 records, 0 violations
+  T22  no files matching glob -> 0 records, 0 files
+  T23  multi-file aggregation: violations summed across files
+  T24  multiple errors in one record reported together
+  T25  format_human: clean output string
+  T26  format_json_output: structure and fields
+  T27  --strict promotes warnings to rc=1 (via check_logs directly)
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from check_inbox_log_schema import (
+    check_logs,
+    format_human,
+    format_json_output,
+    validate_record,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+VALID = {
+    "role": "software_engineer",
+    "normalized_label": "backend",
+    "confidence": 0.85,
+    "source": "substring",
+}
+
+
+def mk(overrides=None, omit=None):
+    """Build a test record from VALID base, applying overrides/omissions."""
+    r = dict(VALID)
+    if omit:
+        for k in omit:
+            r.pop(k, None)
+    if overrides:
+        r.update(overrides)
+    return r
+
+
+def write_jsonl(path, records):
+    with open(path, "w") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+
+
+# ── T01-T02: Valid records ────────────────────────────────────────────────────
+
+
+class TestValidRecords:
+    def test_T01_valid_minimal(self):
+        viol, warn = validate_record(mk(), "f.jsonl", 1)
+        assert viol is None
+        assert warn is None
+
+    def test_T02_valid_all_optional_fields(self):
+        rec = mk({
+            "suggested_family": "engineering",
+            "count": 5,
+            "sample_labels": ["backend dev", "swe"],
+            "matched_tokens": ["backend"],
+            "model": "gpt-4",
+            "prompt_hash": "abc123",
+            "source": "llm",
+        })
+        viol, warn = validate_record(rec, "f.jsonl", 1)
+        assert viol is None
+        assert warn is None  # model is set, so no warning
+
+
+# ── T03-T08: Missing / empty required fields ─────────────────────────────────
+
+
+class TestRequiredFields:
+    def test_T03_missing_role(self):
+        viol, _ = validate_record(mk(omit=["role"]), "f.jsonl", 1)
+        assert viol is not None
+        assert any("role" in e for e in viol["errors"])
+
+    def test_T04_missing_normalized_label(self):
+        viol, _ = validate_record(mk(omit=["normalized_label"]), "f.jsonl", 1)
+        assert viol is not None
+        assert any("normalized_label" in e for e in viol["errors"])
+
+    def test_T05_missing_confidence(self):
+        viol, _ = validate_record(mk(omit=["confidence"]), "f.jsonl", 1)
+        assert viol is not None
+        assert any("confidence" in e for e in viol["errors"])
+
+    def test_T06_missing_source(self):
+        viol, _ = validate_record(mk(omit=["source"]), "f.jsonl", 1)
+        assert viol is not None
+        assert any("source" in e for e in viol["errors"])
+
+    def test_T07_empty_role(self):
+        viol, _ = validate_record(mk({"role": "   "}), "f.jsonl", 1)
+        assert viol is not None
+        assert any("non-empty" in e for e in viol["errors"])
+
+    def test_T08_empty_normalized_label(self):
+        viol, _ = validate_record(
+            mk({"normalized_label": ""}), "f.jsonl", 1
+        )
+        assert viol is not None
+        assert any("non-empty" in e for e in viol["errors"])
+
+
+# ── T09-T11: Confidence range ─────────────────────────────────────────────────
+
+
+class TestConfidence:
+    def test_T09_confidence_below_zero(self):
+        viol, _ = validate_record(mk({"confidence": -0.01}), "f.jsonl", 1)
+        assert viol is not None
+        assert any("[0.0, 1.0]" in e for e in viol["errors"])
+
+    def test_T10_confidence_above_one(self):
+        viol, _ = validate_record(mk({"confidence": 1.001}), "f.jsonl", 1)
+        assert viol is not None
+        assert any("[0.0, 1.0]" in e for e in viol["errors"])
+
+    def test_T11_confidence_at_boundaries(self):
+        for val in (0.0, 1.0):
+            viol, _ = validate_record(mk({"confidence": val}), "f.jsonl", 1)
+            assert viol is None, f"confidence={val} should be valid"
+
+
+# ── T12: Source enum ──────────────────────────────────────────────────────────
+
+
+class TestSource:
+    def test_T12_invalid_source(self):
+        viol, _ = validate_record(mk({"source": "magic"}), "f.jsonl", 1)
+        assert viol is not None
+        assert any("source" in e and "must be one of" in e for e in viol["errors"])
+
+
+# ── T13-T14: Cross-field llm/model warning ────────────────────────────────────
+
+
+class TestLlmModelWarning:
+    def test_T13_llm_without_model_is_warning_not_violation(self):
+        rec = mk({"source": "llm"})
+        # model field absent entirely
+        rec.pop("model", None)
+        viol, warn = validate_record(rec, "f.jsonl", 1)
+        assert viol is None, "should not be a violation"
+        assert warn is not None
+        assert "llm-source" in warn["message"]
+        assert "model" in warn["message"]
+
+    def test_T14_llm_with_model_no_warning(self):
+        rec = mk({"source": "llm", "model": "gpt-4"})
+        viol, warn = validate_record(rec, "f.jsonl", 1)
+        assert viol is None
+        assert warn is None
+
+
+# ── T15-T19: Optional field type validation ───────────────────────────────────
+
+
+class TestOptionalFields:
+    def test_T15_count_negative(self):
+        viol, _ = validate_record(mk({"count": -1}), "f.jsonl", 1)
+        assert viol is not None
+        assert any("count" in e and ">= 0" in e for e in viol["errors"])
+
+    def test_T16_sample_labels_non_string_element(self):
+        viol, _ = validate_record(
+            mk({"sample_labels": ["ok", 42]}), "f.jsonl", 1
+        )
+        assert viol is not None
+        assert any("sample_labels" in e for e in viol["errors"])
+
+    def test_T17_matched_tokens_not_list(self):
+        viol, _ = validate_record(
+            mk({"matched_tokens": "oops"}), "f.jsonl", 1
+        )
+        assert viol is not None
+        assert any("matched_tokens" in e and "list" in e for e in viol["errors"])
+
+    def test_T18_model_wrong_type(self):
+        viol, _ = validate_record(mk({"model": 12345}), "f.jsonl", 1)
+        assert viol is not None
+        assert any("model" in e and "str or null" in e for e in viol["errors"])
+
+    def test_T19_prompt_hash_wrong_type(self):
+        viol, _ = validate_record(mk({"prompt_hash": ["x"]}), "f.jsonl", 1)
+        assert viol is not None
+        assert any("prompt_hash" in e and "str or null" in e for e in viol["errors"])
+
+
+# ── T20-T24: check_logs integration tests ────────────────────────────────────
+
+
+class TestCheckLogs:
+    def test_T20_malformed_json_line(self):
+        with tempfile.TemporaryDirectory() as d:
+            write_jsonl(
+                os.path.join(d, "pattern-suggestions-20260512.jsonl"),
+                []
+            )
+            p = os.path.join(d, "pattern-suggestions-20260512.jsonl")
+            with open(p, "w") as f:
+                f.write("{ not valid json \n")
+            viols, warns, recs, files = check_logs(d)
+            assert files == 1
+            assert any("error" in v for v in viols)
+
+    def test_T21_empty_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(
+                d, "pattern-suggestions-20260512.jsonl"
+            ), "w").close()
+            viols, warns, recs, files = check_logs(d)
+            assert files == 1
+            assert recs == 0
+            assert viols == []
+
+    def test_T22_no_matching_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            # Create a file that does NOT match the glob
+            with open(os.path.join(d, "unrelated.jsonl"), "w") as f:
+                f.write(json.dumps(mk()) + "\n")
+            viols, warns, recs, files = check_logs(d)
+            assert files == 0
+            assert recs == 0
+
+    def test_T23_multi_file_aggregation(self):
+        with tempfile.TemporaryDirectory() as d:
+            for i in range(3):
+                fname = f"pattern-suggestions-2026050{i+1}.jsonl"
+                write_jsonl(
+                    os.path.join(d, fname),
+                    [mk(), mk(omit=["role"])]  # 1 valid, 1 invalid each
+                )
+            viols, warns, recs, files = check_logs(d)
+            assert files == 3
+            assert recs == 3        # only valid records counted
+            assert len(viols) == 3  # 1 violation per file
+
+    def test_T24_multiple_errors_in_one_record(self):
+        rec = {
+            "role": "",              # empty
+            "normalized_label": "",  # empty
+            "confidence": 2.0,       # out of range
+            # source: missing
+        }
+        viol, _ = validate_record(rec, "f.jsonl", 1)
+        assert viol is not None
+        assert len(viol["errors"]) >= 4
+
+
+# ── T25-T27: Formatting and strict mode ──────────────────────────────────────
+
+
+class TestFormatting:
+    def test_T25_format_human_clean(self):
+        out = format_human([], [], 10, 2)
+        assert "OK" in out
+        assert "10" in out
+        assert "2" in out
+
+    def test_T26_format_json_structure(self):
+        viols = [{"file": "f.jsonl", "line": 1, "errors": ["bad"]}]
+        warns = [{"file": "f.jsonl", "line": 2, "message": "warn"}]
+        out = json.loads(format_json_output(viols, warns, 5, 1))
+        assert out["clean"] is False
+        assert out["files_scanned"] == 1
+        assert out["records_validated"] == 5
+        assert len(out["violations"]) == 1
+        assert len(out["warnings"]) == 1
+
+    def test_T27_strict_mode_via_check_logs_warnings(self):
+        with tempfile.TemporaryDirectory() as d:
+            write_jsonl(
+                os.path.join(d, "pattern-suggestions-20260512.jsonl"),
+                [mk({"source": "llm"})],  # llm without model -> warning
+            )
+            viols, warns, recs, files = check_logs(d)
+            # No violations, but there IS a warning
+            assert viols == []
+            assert len(warns) == 1
+            # --strict would return rc=1 when warnings > 0
+            has_violations = len(viols) > 0
+            has_warnings   = len(warns) > 0
+            strict_rc = 1 if (has_violations or has_warnings) else 0
+            assert strict_rc == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/scripts/tests/test_check_inbox_log_schema.py
+++ b/scripts/tests/test_check_inbox_log_schema.py
@@ -262,7 +262,7 @@ class TestCheckLogs:
                 )
             viols, warns, recs, files = check_logs(d)
             assert files == 3
-            assert recs == 3        # only valid records counted
+            assert recs == 6        # all examined records (valid + invalid)
             assert len(viols) == 3  # 1 violation per file
 
     def test_T24_multiple_errors_in_one_record(self):


### PR DESCRIPTION
## Summary

Schema validator for inbox suggestion-log records
(`pattern-suggestions-*.jsonl`).

Spiegel-Track to SR-113 (#114): that PR guards the APPLY-side audit-log;
this PR guards the INBOX-side suggestion-log that `survey learn apply`
and `survey learn review` consume.

`InboxEntry.from_dict()` silently falls back to defaults when fields are
missing (e.g. `confidence=0.0`), so a corrupt record can be silently
applied at wrong confidence. This script catches that **before** apply
runs.

## Changes

| File | Status | Mode | LOC | Tests |
|------|--------|------|-----|-------|
| `scripts/check_inbox_log_schema.py` | NEW | 100755 | ~340 | — |
| `scripts/tests/test_check_inbox_log_schema.py` | NEW | 100644 | ~310 | 27 |

Zero modifications to `survey-cli/`, `.github/workflows/`,
`pyproject.toml`, `requirements.txt`, or any other `scripts/*` files.

## CLI Surface

```bash
python scripts/check_inbox_log_schema.py
    [--logs DIR]                    # default: survey-cli/logs
    [--exit-non-zero-on-violation]  # rc=1 if violations > 0
    [--strict]                      # rc=1 if warnings > 0 too
    [--json]                        # JSON output
    [--quiet]                       # suppress output (exit code only)
```

## Schema Enforced

**Required:** `role` (non-empty str), `normalized_label` (non-empty str),
`confidence` (float 0.0–1.0), `source` (`substring`|`llm`|`manual`).

**Optional (typed):** `suggested_family`, `count` (int ≥ 0),
`sample_labels` (list[str]), `matched_tokens` (list[str]),
`model` (str|null), `prompt_hash` (str|null).

**Cross-field warning:** `source=="llm"` with `model is None`
→ *"pre-SR-57 legacy?"* — warning, not error.

## Test Coverage (27 tests)

- T01–T02: valid minimal + full-optional records
- T03–T08: missing/empty required fields
- T09–T11: confidence range (below, above, exact boundaries)
- T12: invalid source enum
- T13–T14: llm/model cross-field warning logic
- T15–T19: optional field type violations
- T20–T24: `check_logs` integration (malformed JSON, empty file,
  no-match glob, multi-file aggregation, multi-error record)
- T25–T27: formatting (human, JSON) + strict-mode exit code logic

Syntax verified: `ast.parse()` clean on both files before push.

Closes #117