### PR TITLE
fix(security): add MissingSecretError stub to unblock CI collection

### DIFF
--- a/survey-cli/survey/security/__init__.py
+++ b/survey-cli/survey/security/__init__.py
@@ -12,6 +12,17 @@ from dataclasses import dataclass
 from typing import Optional
 
 
+class MissingSecretError(RuntimeError):
+    """Raised when a required secret has no resolved value.
+
+    Placeholder stub for SR-63 (#62) fail-closed contract. The current
+    SecretsClient still returns hardcoded fallbacks; the test in
+    tests/test_security.py is module-level-skipped and uses this symbol
+    only to satisfy its import. Promoting fail-closed behavior is tracked
+    separately under SR-63.
+    """
+
+
 @dataclass
 class CPXCredentials:
     app_id: str = ""


### PR DESCRIPTION
Trivial 1-class import stub. Unblocks `test (3.12)` and `test (3.13)` which were collection-error-ing on `test_security.py`s pytestmark.skip-prefixed import. See commit message for full rationale.