### PR TITLE
fix(tests): test_stealth_memory — add balance_earned to local outcome dict

### DIFF
--- a/survey-cli/tests/test_stealth_memory.py
+++ b/survey-cli/tests/test_stealth_memory.py
@@ -70,6 +70,7 @@ def test_update_stealth_memory_success_local_jsonl():
                 "success": state.balance_after > state.balance_before,
                 "balance_before": state.balance_before,
                 "balance_after": state.balance_after,
+                "balance_earned": max(0, state.balance_after - state.balance_before),
                 "status": state.status,
             }
             assert outcome["success"] is True


### PR DESCRIPTION
Pre-existing KeyError that was blocking CI on main. 1-line fix: add the missing `balance_earned` field to the locally-constructed outcome dict. Aligns with author intent and the companion test at line 91 which already includes the key.