### PR TITLE
feat(captcha): add 5-stage fallback chain with NIM + Vercel AI Gateway

### DIFF
--- a/survey-cli/survey/captcha/__init__.py
+++ b/survey-cli/survey/captcha/__init__.py
@@ -1,5 +1,17 @@
-"""Captcha detection and solving (SR-68, 2026-05-11)."""
+"""Captcha detection and solving (SR-68, SR-138)."""
 
 from .drag_drop_solver import solve_puzzle
+from .fallback_chain import (
+    CaptchaUnsolvedError,
+    FallbackChain,
+    StepTrace,
+    solve_with_fallback,
+)
 
-__all__ = ["solve_puzzle"]
+__all__ = [
+    "solve_puzzle",
+    "CaptchaUnsolvedError",
+    "FallbackChain",
+    "StepTrace",
+    "solve_with_fallback",
+]

--- a/survey-cli/survey/captcha/audio_solver.py
+++ b/survey-cli/survey/captcha/audio_solver.py
@@ -1,0 +1,491 @@
+"""================================================================================
+AUDIO SOLVER — NVIDIA Parakeet ASR für reCAPTCHA-v2 / hCaptcha Audio Challenges
+================================================================================
+
+MODUL-KONZEPT (SR-138, 2026-05-12):
+    Dieses Modul implementiert Schritt 4 der Captcha-Fallback-Chain.
+    Löst Audio-Captchas durch Transkription mit NVIDIA NIM Parakeet ASR.
+
+WARUM AUDIO ALS FALLBACK?
+    - reCAPTCHA-v2 und hCaptcha bieten Audio-Accessibility-Modus
+    - Audio-Challenges sind oft einfacher als visuelle Puzzles
+    - NVIDIA Parakeet CTC 1.1B ist state-of-the-art ASR, kostenlos auf NIM
+    - Alternative: Nemotron-3-Nano-Omni hat multimodalen Audio-Mode
+
+WORKFLOW:
+    1. Aktiviere Audio-Modus im Captcha (Accessibility Button)
+    2. Download Audio-Datei (MP3/WAV)
+    3. Transkribiere via NVIDIA Parakeet ASR
+    4. Gib transkribierten Text in das Antwortfeld ein
+
+UNTERSTÜTZTE CAPTCHA-TYPEN:
+    ✅ recaptcha (v2 mit Audio-Option)
+    ✅ hcaptcha (mit Accessibility-Audio)
+    ❌ turnstile — kein Audio-Modus
+    ❌ geetest — kein Audio-Modus
+    ❌ visual_text — kein Audio
+
+API (konform mit Solver-Interface aus captcha_router):
+    solve(cdp, detection) -> CaptchaResult
+
+NVIDIA NIM ENDPOINT:
+    Model: nvidia/parakeet-ctc-1.1b
+    Docs: https://build.nvidia.com/nvidia/parakeet-ctc-1_1b
+
+Module Status: NEW (SR-138, 2026-05-12)
+================================================================================
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError, URLError
+
+logger = logging.getLogger("audio_solver")
+
+# ── CONFIG ─────────────────────────────────────────────────────────────────
+
+NIM_ASR_MODEL = "nvidia/parakeet-ctc-1.1b"
+NIM_BASE_URL = "https://integrate.api.nvidia.com/v1"
+MAX_AUDIO_DURATION_S = 30
+TIMEOUT_S = 30
+RETRIES = 2
+
+# Captcha-Typen die Audio-Modus unterstützen
+SUPPORTED_TYPES = frozenset({
+    "recaptcha",
+    "hcaptcha",
+})
+
+# ── RESULT DATACLASS ───────────────────────────────────────────────────────
+
+@dataclass
+class CaptchaResult:
+    """Ergebnis eines Captcha-Lösungsversuchs."""
+    solved: bool
+    captcha_type: str = ""
+    token: str = ""
+    elapsed_ms: float = 0.0
+    reason: str = "ok"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+# ── AUDIO EXTRACTION ───────────────────────────────────────────────────────
+
+def _click_audio_button(cdp, ctype: str) -> bool:
+    """Klicke den Audio-Accessibility-Button im Captcha iframe.
+
+    Args:
+        cdp: CDPConnection instance
+        ctype: Captcha-Typ (recaptcha oder hcaptcha)
+
+    Returns:
+        True wenn Button gefunden und geklickt
+    """
+    if ctype == "recaptcha":
+        # reCAPTCHA Audio-Button Selektoren
+        selectors = [
+            "#recaptcha-audio-button",
+            "button.rc-button-audio",
+            "[aria-label*='audio']",
+            "[title*='audio']",
+        ]
+    elif ctype == "hcaptcha":
+        # hCaptcha Accessibility-Button
+        selectors = [
+            "[aria-label*='accessibility']",
+            "[title*='accessibility']",
+            ".challenge-link",
+            "a[href*='accessibility']",
+        ]
+    else:
+        return False
+
+    for selector in selectors:
+        js = f"""(function(){{
+            var btn = document.querySelector('{selector}');
+            if (btn) {{
+                btn.click();
+                return true;
+            }}
+            return false;
+        }})()"""
+        try:
+            resp = cdp.call_result("Runtime.evaluate", {"expression": js})
+            if resp.get("result", {}).get("value"):
+                logger.info("Audio button clicked: %s", selector)
+                time.sleep(1)  # Warte auf Audio-Challenge load
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _extract_audio_url(cdp, ctype: str) -> Optional[str]:
+    """Extrahiere die Audio-URL aus dem Captcha iframe.
+
+    Args:
+        cdp: CDPConnection instance
+        ctype: Captcha-Typ
+
+    Returns:
+        Audio-URL oder None
+    """
+    if ctype == "recaptcha":
+        # reCAPTCHA Audio-Element
+        js = """(function(){
+            var audio = document.querySelector('#audio-source, audio source, .rc-audiochallenge-play-button');
+            if (audio && audio.src) return audio.src;
+            var link = document.querySelector('a.rc-audiochallenge-download-link');
+            if (link) return link.href;
+            return null;
+        })()"""
+    elif ctype == "hcaptcha":
+        # hCaptcha Audio-Element
+        js = """(function(){
+            var audio = document.querySelector('audio source, audio');
+            if (audio && audio.src) return audio.src;
+            return null;
+        })()"""
+    else:
+        return None
+
+    try:
+        resp = cdp.call_result("Runtime.evaluate", {"expression": js})
+        url = resp.get("result", {}).get("value")
+        if url:
+            logger.info("Audio URL extracted: %s", url[:80])
+        return url
+    except Exception as e:
+        logger.warning("Audio URL extraction failed: %s", e)
+        return None
+
+
+def _download_audio_b64(audio_url: str) -> Optional[str]:
+    """Download Audio-Datei und encode als Base64.
+
+    Args:
+        audio_url: URL zur Audio-Datei
+
+    Returns:
+        Base64-encoded Audio oder None
+    """
+    try:
+        req = Request(audio_url, headers={"User-Agent": "Mozilla/5.0"})
+        with urlopen(req, timeout=TIMEOUT_S) as resp:
+            audio_data = resp.read()
+            return base64.b64encode(audio_data).decode("utf-8")
+    except Exception as e:
+        logger.warning("Audio download failed: %s", e)
+        return None
+
+
+# ── NIM ASR CLIENT ─────────────────────────────────────────────────────────
+
+class AudioSolver:
+    """NVIDIA NIM Parakeet ASR Solver für Audio-Captchas.
+
+    Transkribiert reCAPTCHA-v2 und hCaptcha Audio-Challenges
+    via NVIDIA NIM's Parakeet CTC 1.1B ASR Modell (kostenlos).
+    """
+
+    def __init__(self, api_key: str = None):
+        self.api_key = api_key or os.getenv("NVIDIA_API_KEY")
+        self._available = bool(self.api_key)
+        self.consecutive_failures = 0
+
+        if not self._available:
+            logger.warning("NVIDIA_API_KEY not set — AudioSolver unavailable")
+
+    @property
+    def available(self) -> bool:
+        return self._available and self.consecutive_failures < 3
+
+    def _record_failure(self, reason: str):
+        self.consecutive_failures += 1
+        logger.warning("AudioSolver failure: %s (count: %d)", reason, self.consecutive_failures)
+
+    def _record_success(self):
+        self.consecutive_failures = 0
+
+    def _transcribe_audio(self, audio_b64: str) -> Optional[str]:
+        """Transkribiere Audio via NVIDIA NIM Parakeet ASR.
+
+        Args:
+            audio_b64: Base64-encoded Audio (MP3/WAV)
+
+        Returns:
+            Transkribierter Text oder None
+        """
+        if not self.api_key:
+            return None
+
+        # NIM ASR API payload
+        payload = {
+            "audio": audio_b64,
+            "language": "en",  # reCAPTCHA/hCaptcha Audio ist typischerweise Englisch
+        }
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+
+        for attempt in range(1, RETRIES + 1):
+            try:
+                req = Request(
+                    f"{NIM_BASE_URL}/audio/transcriptions",
+                    data=json.dumps(payload).encode("utf-8"),
+                    headers=headers,
+                    method="POST",
+                )
+                with urlopen(req, timeout=TIMEOUT_S) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    text = data.get("text", "").strip()
+                    self._record_success()
+                    return text
+            except HTTPError as e:
+                self._record_failure(f"http_{e.code}")
+                if e.code == 429 and attempt < RETRIES:
+                    time.sleep(5)
+                    continue
+            except URLError as e:
+                self._record_failure(f"network: {e.reason}")
+                if attempt < RETRIES:
+                    time.sleep(2 ** attempt)
+            except Exception as e:
+                self._record_failure(f"unknown: {e}")
+                break
+        return None
+
+    def _transcribe_via_openai_compat(self, audio_b64: str) -> Optional[str]:
+        """Alternative: Transkribiere via OpenAI-kompatible API.
+
+        Nutzt Nemotron-Omni wenn Parakeet nicht funktioniert.
+        """
+        try:
+            from openai import OpenAI
+            client = OpenAI(api_key=self.api_key, base_url=NIM_BASE_URL)
+
+            # Decode audio to temp file (OpenAI API braucht file-like object)
+            audio_bytes = base64.b64decode(audio_b64)
+            with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as f:
+                f.write(audio_bytes)
+                temp_path = f.name
+
+            try:
+                with open(temp_path, "rb") as audio_file:
+                    response = client.audio.transcriptions.create(
+                        model=NIM_ASR_MODEL,
+                        file=audio_file,
+                        language="en",
+                    )
+                    return response.text.strip()
+            finally:
+                os.unlink(temp_path)
+        except Exception as e:
+            logger.warning("OpenAI-compat transcription failed: %s", e)
+            return None
+
+    def _submit_answer(self, cdp, answer: str, ctype: str) -> bool:
+        """Submit transcribed answer to captcha input field.
+
+        Args:
+            cdp: CDPConnection instance
+            answer: Transcribed text to enter
+            ctype: Captcha type
+
+        Returns:
+            True if submission succeeded
+        """
+        if ctype == "recaptcha":
+            selectors = [
+                "#audio-response",
+                "input.rc-audiochallenge-response-field",
+                "[name='audio-response']",
+            ]
+        elif ctype == "hcaptcha":
+            selectors = [
+                "input[type='text']",
+                ".answer-input",
+            ]
+        else:
+            return False
+
+        # Find and fill input
+        for selector in selectors:
+            js = f"""(function(){{
+                var inp = document.querySelector('{selector}');
+                if (inp) {{
+                    inp.focus();
+                    inp.value = '{answer}';
+                    inp.dispatchEvent(new Event('input', {{bubbles: true}}));
+                    return true;
+                }}
+                return false;
+            }})()"""
+            try:
+                resp = cdp.call_result("Runtime.evaluate", {"expression": js})
+                if resp.get("result", {}).get("value"):
+                    logger.info("Answer submitted to: %s", selector)
+                    break
+            except Exception:
+                continue
+        else:
+            return False
+
+        # Click verify button
+        time.sleep(0.3)
+        verify_selectors = [
+            "#recaptcha-verify-button",
+            ".rc-button-default",
+            "button[type='submit']",
+            ".verify-button",
+        ]
+        for selector in verify_selectors:
+            js = f"""(function(){{
+                var btn = document.querySelector('{selector}');
+                if (btn) {{
+                    btn.click();
+                    return true;
+                }}
+                return false;
+            }})()"""
+            try:
+                resp = cdp.call_result("Runtime.evaluate", {"expression": js})
+                if resp.get("result", {}).get("value"):
+                    logger.info("Verify button clicked")
+                    return True
+            except Exception:
+                continue
+        return True  # Input filled, even if verify button not found
+
+    def solve(self, cdp, detection) -> CaptchaResult:
+        """Hauptmethode: Löst Audio-Captcha via NIM Parakeet ASR.
+
+        Args:
+            cdp: CDPConnection instance
+            detection: CaptchaDetection mit captcha_type
+
+        Returns:
+            CaptchaResult mit solved=True/False und Details
+        """
+        t0 = time.time()
+        ctype = detection.captcha_type
+
+        # Check support
+        if ctype not in SUPPORTED_TYPES:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="audio_not_supported_for_type",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Check availability
+        if not self.available:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="asr_unavailable",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Step 1: Click audio button
+        if not _click_audio_button(cdp, ctype):
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="audio_button_not_found",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Step 2: Extract audio URL
+        audio_url = _extract_audio_url(cdp, ctype)
+        if not audio_url:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="audio_url_not_found",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Step 3: Download audio
+        audio_b64 = _download_audio_b64(audio_url)
+        if not audio_b64:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="audio_download_failed",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Step 4: Transcribe
+        transcript = self._transcribe_audio(audio_b64)
+        if not transcript:
+            # Fallback to OpenAI-compatible endpoint
+            transcript = self._transcribe_via_openai_compat(audio_b64)
+
+        if not transcript:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="transcription_failed",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Clean transcript (remove punctuation, lowercase)
+        clean_answer = re.sub(r"[^\w\s]", "", transcript).lower().strip()
+        logger.info("Transcription: '%s' → '%s'", transcript, clean_answer)
+
+        # Step 5: Submit answer
+        success = self._submit_answer(cdp, clean_answer, ctype)
+
+        return CaptchaResult(
+            solved=success,
+            captcha_type=ctype,
+            reason="ok" if success else "submission_failed",
+            elapsed_ms=(time.time() - t0) * 1000,
+            extra={
+                "model": NIM_ASR_MODEL,
+                "transcript": transcript,
+                "clean_answer": clean_answer,
+            },
+        )
+
+
+# ── SINGLETON + PUBLIC API ─────────────────────────────────────────────────
+
+_solver_instance: Optional[AudioSolver] = None
+
+
+def get_solver() -> AudioSolver:
+    """Singleton-Accessor für AudioSolver."""
+    global _solver_instance
+    if _solver_instance is None:
+        _solver_instance = AudioSolver()
+    return _solver_instance
+
+
+def solve(cdp, detection) -> CaptchaResult:
+    """Public API: Löst Audio-Captcha via NVIDIA Parakeet ASR.
+
+    Nur für reCAPTCHA-v2 und hCaptcha mit Audio-Modus.
+
+    Args:
+        cdp: CDPConnection instance
+        detection: CaptchaDetection mit captcha_type
+
+    Returns:
+        CaptchaResult mit solved, captcha_type, reason, elapsed_ms, extra
+    """
+    return get_solver().solve(cdp, detection)

--- a/survey-cli/survey/captcha/fallback_chain.py
+++ b/survey-cli/survey/captcha/fallback_chain.py
@@ -1,0 +1,429 @@
+"""================================================================================
+CAPTCHA FALLBACK CHAIN — 5-Stufen Zero-Cost Defense in Depth (SR-138)
+================================================================================
+
+MODUL-KONZEPT (SR-138, 2026-05-12):
+    Orchestriert die 5-stufige Captcha-Fallback-Chain. Wenn ein Solver
+    fehlschlägt, wird der nächste versucht. Alle Solver sind KOSTENLOS
+    (keine bezahlten Services wie 2Captcha, Anti-Captcha, etc.).
+
+CHAIN-REIHENFOLGE:
+    [1] NIM Primary (Nemotron-3-Nano-Omni) — existierender Solver
+    [2] NIM Secondary (Qwen2.5-VL-72B) — nim_secondary_solver.py
+    [3] Vercel AI Gateway (Gemini → Claude) — gateway_solver.py
+    [4] Audio Solver (Parakeet ASR) — audio_solver.py
+    [5] Human Handoff (JSONL Log) — logs/captcha-failures-*.jsonl
+
+WARUM DIESE REIHENFOLGE?
+    - [1+2] Zwei verschiedene NIM-Modelle reduzieren modellspezifische Fehler
+    - [3] Gateway hat Gemini (schnell, native grounding) + Claude (reasoning)
+    - [4] Audio als letzter algorithmischer Versuch (nur für reCAPTCHA/hCaptcha)
+    - [5] Niemals bezahlter Service — wir loggen und eskalieren
+
+STEP-TRACE:
+    Jeder Schritt wird mit Ergebnis protokolliert für Debugging:
+    [{solver: "nim_primary", outcome: "failed", error: "timeout"}, ...]
+
+HUMAN HANDOFF:
+    Bei finalem Fehler wird `logs/captcha-failures-YYYYMMDD.jsonl` geschrieben:
+    {
+        "timestamp": "2026-05-12T14:30:00Z",
+        "detected_type": "angular_drag_drop",
+        "page_url": "https://...",
+        "step_trace": [...],
+        "screenshot_b64": "iVBOR..."
+    }
+
+PUBLIC API:
+    solve_with_fallback(cdp, detection, page_url) -> CaptchaResult | None
+
+EXCEPTION:
+    CaptchaUnsolvedError — raised wenn alle Schritte fehlschlagen
+
+Module Status: NEW (SR-138, 2026-05-12)
+================================================================================
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("fallback_chain")
+
+# ── EXCEPTION ──────────────────────────────────────────────────────────────
+
+class CaptchaUnsolvedError(Exception):
+    """Raised wenn alle Fallback-Schritte fehlgeschlagen sind.
+
+    Attributes:
+        captcha_type: Der Typ des ungelösten Captchas
+        step_trace: Liste aller versuchten Schritte mit Ergebnissen
+        page_url: URL der Seite mit dem Captcha
+    """
+
+    def __init__(self, captcha_type: str, step_trace: list, page_url: str = ""):
+        self.captcha_type = captcha_type
+        self.step_trace = step_trace
+        self.page_url = page_url
+        super().__init__(
+            f"Captcha '{captcha_type}' unsolved after {len(step_trace)} attempts. "
+            f"Last error: {step_trace[-1].get('error', 'unknown') if step_trace else 'none'}"
+        )
+
+
+# ── RESULT DATACLASS ───────────────────────────────────────────────────────
+
+@dataclass
+class CaptchaResult:
+    """Ergebnis eines Captcha-Lösungsversuchs."""
+    solved: bool
+    captcha_type: str = ""
+    token: str = ""
+    elapsed_ms: float = 0.0
+    reason: str = "ok"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class StepResult:
+    """Ergebnis eines einzelnen Chain-Schritts."""
+    solver: str
+    outcome: str  # "success", "failed", "skipped"
+    error: str = ""
+    elapsed_ms: float = 0.0
+
+
+# ── SOLVER IMPORTS ─────────────────────────────────────────────────────────
+
+def _get_nim_primary_solver():
+    """Import existierender NIM Primary Solver (Nemotron-3-Nano-Omni)."""
+    try:
+        # Der existierende Solver in captcha_adapters oder drag_drop_solver
+        from .drag_drop_solver import solve_puzzle
+        return solve_puzzle
+    except ImportError:
+        pass
+
+    # Fallback: Versuch über captcha_adapters
+    try:
+        from ..captcha_adapters import get_adapter
+        return get_adapter("angular_drag_drop")
+    except ImportError:
+        pass
+
+    return None
+
+
+def _get_nim_secondary_solver():
+    """Import NIM Secondary Solver (Qwen2.5-VL-72B)."""
+    try:
+        from .nim_secondary_solver import solve
+        return solve
+    except ImportError as e:
+        logger.warning("nim_secondary_solver import failed: %s", e)
+        return None
+
+
+def _get_gateway_solver():
+    """Import Vercel AI Gateway Solver."""
+    try:
+        from .gateway_solver import solve
+        return solve
+    except ImportError as e:
+        logger.warning("gateway_solver import failed: %s", e)
+        return None
+
+
+def _get_audio_solver():
+    """Import Audio Solver (Parakeet ASR)."""
+    try:
+        from .audio_solver import solve
+        return solve
+    except ImportError as e:
+        logger.warning("audio_solver import failed: %s", e)
+        return None
+
+
+# ── LOGGING ────────────────────────────────────────────────────────────────
+
+def _ensure_logs_dir() -> Path:
+    """Stelle sicher dass logs/ Verzeichnis existiert."""
+    logs_dir = Path("logs")
+    logs_dir.mkdir(exist_ok=True)
+    return logs_dir
+
+
+def _capture_screenshot_b64(cdp) -> Optional[str]:
+    """Capture Screenshot für Failure-Log."""
+    try:
+        resp = cdp.call_result("Page.captureScreenshot", {"format": "png", "quality": 60})
+        return resp.get("data")
+    except Exception:
+        return None
+
+
+def _log_human_handoff(
+    cdp,
+    detection,
+    page_url: str,
+    step_trace: list[dict],
+) -> str:
+    """Schreibe Failure-Log für Human Handoff.
+
+    Args:
+        cdp: CDPConnection instance
+        detection: CaptchaDetection
+        page_url: URL der Seite
+        step_trace: Liste aller versuchten Schritte
+
+    Returns:
+        Pfad zur Log-Datei
+    """
+    logs_dir = _ensure_logs_dir()
+    date_str = datetime.utcnow().strftime("%Y%m%d")
+    log_path = logs_dir / f"captcha-failures-{date_str}.jsonl"
+
+    # Capture screenshot
+    screenshot_b64 = _capture_screenshot_b64(cdp)
+
+    # Build log entry
+    entry = {
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "detected_type": detection.captcha_type,
+        "page_url": page_url,
+        "frame_id": detection.frame_id,
+        "dom_hint": detection.dom_hint,
+        "step_trace": step_trace,
+        "screenshot_b64": screenshot_b64 or "",
+    }
+
+    # Append to JSONL
+    with open(log_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+    logger.info("Human handoff logged to: %s", log_path)
+    return str(log_path)
+
+
+# ── FALLBACK CHAIN ─────────────────────────────────────────────────────────
+
+class FallbackChain:
+    """Orchestriert die 5-stufige Captcha-Fallback-Chain.
+
+    Usage:
+        chain = FallbackChain()
+        result = chain.solve_with_fallback(cdp, detection, page_url)
+
+    Die Chain short-circuits bei erstem Erfolg.
+    Bei finalem Fehler wird CaptchaUnsolvedError geraised.
+    """
+
+    def __init__(self):
+        """Initialisiere Chain mit allen verfügbaren Solvern."""
+        self._solvers: list[tuple[str, Callable | None]] = [
+            ("nim_primary", _get_nim_primary_solver()),
+            ("nim_secondary", _get_nim_secondary_solver()),
+            ("gateway", _get_gateway_solver()),
+            ("audio", _get_audio_solver()),
+        ]
+
+    def _try_solver(
+        self,
+        name: str,
+        solver: Callable | None,
+        cdp,
+        detection,
+    ) -> tuple[Optional[CaptchaResult], StepResult]:
+        """Versuche einen einzelnen Solver.
+
+        Args:
+            name: Name des Solvers für Logging
+            solver: Solver-Funktion oder None
+            cdp: CDPConnection
+            detection: CaptchaDetection
+
+        Returns:
+            (CaptchaResult | None, StepResult)
+        """
+        t0 = time.time()
+
+        # Skip if solver not available
+        if solver is None:
+            return None, StepResult(
+                solver=name,
+                outcome="skipped",
+                error="solver_not_available",
+                elapsed_ms=0,
+            )
+
+        try:
+            # Rufe Solver auf
+            result = solver(cdp, detection)
+
+            elapsed = (time.time() - t0) * 1000
+
+            # Prüfe ob gelöst
+            if isinstance(result, dict):
+                solved = result.get("solved", False)
+            elif hasattr(result, "solved"):
+                solved = result.solved
+            else:
+                solved = bool(result)
+
+            if solved:
+                logger.info("Chain step '%s' succeeded in %.0fms", name, elapsed)
+                return result, StepResult(
+                    solver=name,
+                    outcome="success",
+                    elapsed_ms=elapsed,
+                )
+            else:
+                reason = getattr(result, "reason", "") if hasattr(result, "reason") else str(result)
+                logger.info("Chain step '%s' failed: %s", name, reason)
+                return None, StepResult(
+                    solver=name,
+                    outcome="failed",
+                    error=reason[:100],
+                    elapsed_ms=elapsed,
+                )
+
+        except Exception as e:
+            elapsed = (time.time() - t0) * 1000
+            logger.warning("Chain step '%s' exception: %s", name, e)
+            return None, StepResult(
+                solver=name,
+                outcome="failed",
+                error=f"exception: {str(e)[:80]}",
+                elapsed_ms=elapsed,
+            )
+
+    def solve_with_fallback(
+        self,
+        cdp,
+        detection,
+        page_url: str = "",
+    ) -> CaptchaResult:
+        """Hauptmethode: Durchlaufe Fallback-Chain bis Erfolg oder Handoff.
+
+        Args:
+            cdp: CDPConnection instance
+            detection: CaptchaDetection mit captcha_type und dom_hint
+            page_url: URL der aktuellen Seite (für Logging)
+
+        Returns:
+            CaptchaResult bei Erfolg
+
+        Raises:
+            CaptchaUnsolvedError: Wenn alle Schritte fehlschlagen
+        """
+        t0 = time.time()
+        step_trace: list[dict] = []
+        ctype = detection.captcha_type
+
+        logger.info(
+            "Starting fallback chain for '%s' captcha (page: %s)",
+            ctype, page_url[:60] if page_url else "unknown"
+        )
+
+        # Durchlaufe alle Solver
+        for name, solver in self._solvers:
+            # Spezialfall: Audio-Solver nur für reCAPTCHA/hCaptcha
+            if name == "audio" and ctype not in ("recaptcha", "hcaptcha"):
+                step_trace.append({
+                    "solver": name,
+                    "outcome": "skipped",
+                    "error": "audio_not_applicable",
+                    "elapsed_ms": 0,
+                })
+                continue
+
+            result, step_result = self._try_solver(name, solver, cdp, detection)
+            step_trace.append({
+                "solver": step_result.solver,
+                "outcome": step_result.outcome,
+                "error": step_result.error,
+                "elapsed_ms": step_result.elapsed_ms,
+            })
+
+            # Short-circuit on success
+            if result is not None:
+                # Ensure CaptchaResult type
+                if isinstance(result, CaptchaResult):
+                    result.extra["step_trace"] = step_trace
+                    result.elapsed_ms = (time.time() - t0) * 1000
+                    return result
+                elif isinstance(result, dict):
+                    return CaptchaResult(
+                        solved=True,
+                        captcha_type=ctype,
+                        token=result.get("token", ""),
+                        elapsed_ms=(time.time() - t0) * 1000,
+                        reason="ok",
+                        extra={"step_trace": step_trace, **result},
+                    )
+
+        # Step 5: Human Handoff
+        logger.warning(
+            "All %d solvers failed for '%s' captcha — logging for human handoff",
+            len(self._solvers), ctype
+        )
+        log_path = _log_human_handoff(cdp, detection, page_url, step_trace)
+        step_trace.append({
+            "solver": "human_handoff",
+            "outcome": "logged",
+            "error": "",
+            "elapsed_ms": 0,
+            "log_path": log_path,
+        })
+
+        # Raise exception
+        raise CaptchaUnsolvedError(
+            captcha_type=ctype,
+            step_trace=step_trace,
+            page_url=page_url,
+        )
+
+
+# ── SINGLETON + PUBLIC API ─────────────────────────────────────────────────
+
+_chain_instance: Optional[FallbackChain] = None
+
+
+def get_chain() -> FallbackChain:
+    """Singleton-Accessor für FallbackChain."""
+    global _chain_instance
+    if _chain_instance is None:
+        _chain_instance = FallbackChain()
+    return _chain_instance
+
+
+def solve_with_fallback(cdp, detection, page_url: str = "") -> CaptchaResult:
+    """Public API: Löst Captcha mit 5-stufiger Fallback-Chain.
+
+    Chain-Reihenfolge:
+    [1] NIM Primary (Nemotron-3-Nano-Omni)
+    [2] NIM Secondary (Qwen2.5-VL-72B)
+    [3] Vercel AI Gateway (Gemini → Claude)
+    [4] Audio Solver (Parakeet ASR, nur für reCAPTCHA/hCaptcha)
+    [5] Human Handoff (Log to JSONL)
+
+    Args:
+        cdp: CDPConnection instance
+        detection: CaptchaDetection mit captcha_type und dom_hint
+        page_url: URL der aktuellen Seite
+
+    Returns:
+        CaptchaResult bei Erfolg
+
+    Raises:
+        CaptchaUnsolvedError: Wenn alle Schritte fehlschlagen
+    """
+    return get_chain().solve_with_fallback(cdp, detection, page_url)

--- a/survey-cli/survey/captcha/gateway_solver.py
+++ b/survey-cli/survey/captcha/gateway_solver.py
@@ -1,0 +1,609 @@
+"""================================================================================
+VERCEL AI GATEWAY SOLVER — Gemini 3.1 Flash + Claude Opus 4.7 Fallback
+================================================================================
+
+MODUL-KONZEPT (SR-138, 2026-05-12):
+    Dieses Modul implementiert Schritt 3 der Captcha-Fallback-Chain.
+    Nutzt Vercel AI Gateway für zero-config Zugriff auf:
+    - Primary: google/gemini-3.1-flash-image-preview (schnell, native bounding-box)
+    - Fallback: anthropic/claude-opus-4.7 (starkes vision-reasoning)
+
+WARUM VERCEL AI GATEWAY?
+    - Zero-config: Kein Provider-SDK nötig, nur AI_GATEWAY_API_KEY
+    - Model-String Format: "provider/model-name" (z.B. "google/gemini-3.1-flash-image-preview")
+    - Unified API: Gleiche Schnittstelle für alle Modelle
+    - Kostenlos für v0-Projekte mit gesetztem API-Key
+
+GRACEFUL DEGRADATION:
+    - Wenn AI_GATEWAY_API_KEY nicht gesetzt → Chain überspringt diesen Schritt
+    - Kein Crash, nur Warning im Log
+    - Nächster Schritt (audio_solver) wird versucht
+
+UNTERSTÜTZTE CAPTCHA-TYPEN:
+    ✅ angular_drag_drop — Drag-Drop Puzzles
+    ✅ visual_text — Text-Captchas
+    ✅ geetest_v4 — Slider/Click Captchas
+    ✅ hcaptcha, recaptcha — Image-Selection Captchas (nur visuell, kein Token)
+    ✅ turnstile — Cloudflare Challenges
+
+API (konform mit Solver-Interface aus captcha_router):
+    solve(cdp, detection) -> CaptchaResult
+
+VERCEL AI GATEWAY DOCS:
+    https://vercel.com/docs/ai-gateway/capabilities
+    Model strings: "google/gemini-3.1-flash-image-preview", "anthropic/claude-opus-4.7"
+
+Module Status: NEW (SR-138, 2026-05-12)
+================================================================================
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError, URLError
+
+logger = logging.getLogger("gateway_solver")
+
+# ── CONFIG ─────────────────────────────────────────────────────────────────
+
+GATEWAY_BASE_URL = "https://api.vercel.ai/v1"
+GATEWAY_PRIMARY_MODEL = "google/gemini-3.1-flash-image-preview"
+GATEWAY_FALLBACK_MODEL = "anthropic/claude-opus-4.7"
+MAX_TOKENS = 512
+TIMEOUT_S = 30
+RETRIES = 2
+
+# Alle Captcha-Typen die dieser Solver unterstützt
+SUPPORTED_TYPES = frozenset({
+    "angular_drag_drop",
+    "visual_text",
+    "geetest_v4",
+    "geetest_v3",
+    "slider",
+    "click_captcha",
+    "hcaptcha",
+    "recaptcha",
+    "turnstile",
+})
+
+# ── RESULT DATACLASS ───────────────────────────────────────────────────────
+
+@dataclass
+class CaptchaResult:
+    """Ergebnis eines Captcha-Lösungsversuchs."""
+    solved: bool
+    captcha_type: str = ""
+    token: str = ""
+    elapsed_ms: float = 0.0
+    reason: str = "ok"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+# ── SCREENSHOT CAPTURE ─────────────────────────────────────────────────────
+
+def _capture_screenshot_b64(cdp, frame_id: str = "") -> Optional[str]:
+    """Capture Screenshot als Base64 PNG."""
+    try:
+        params = {"format": "png", "quality": 80}
+        resp = cdp.call_result("Page.captureScreenshot", params)
+        return resp.get("data")
+    except Exception as e:
+        logger.warning("Screenshot capture failed: %s", e)
+        return None
+
+
+# ── VISION PROMPT BUILDERS ─────────────────────────────────────────────────
+
+def _build_unified_prompt(detection) -> str:
+    """Unified prompt für alle Captcha-Typen mit Gemini/Claude.
+
+    Diese Modelle sind intelligent genug für einen generischen Prompt,
+    der alle Captcha-Varianten abdeckt.
+    """
+    ctype = detection.captcha_type
+    dom_hint = detection.dom_hint or ""
+
+    return f"""You are a CAPTCHA solving assistant. Analyze this image and solve the CAPTCHA.
+
+CAPTCHA TYPE DETECTED: {ctype}
+ADDITIONAL HINT: {dom_hint}
+
+TASK: Based on the CAPTCHA type, provide the solution:
+
+FOR DRAG-DROP PUZZLES:
+- Find the element that needs to be dragged (often a number or shape)
+- Find the drop zone
+- Return source and target coordinates
+
+FOR TEXT CAPTCHAS:
+- Read the distorted text characters
+- Return the exact text
+
+FOR SLIDER PUZZLES:
+- Find the gap/hole in the background image
+- Calculate the distance to slide
+
+FOR CLICK-BASED CAPTCHAS (select images):
+- Identify which images match the instruction
+- Return coordinates of each image to click
+
+FOR CLOUDFLARE TURNSTILE / CHECKBOX:
+- Find the checkbox or button to click
+- Return its coordinates
+
+OUTPUT FORMAT (JSON only, no markdown, no explanation):
+{{
+    "action_type": "drag" | "text" | "slide" | "click" | "checkbox",
+    "solved": true,
+    "data": {{
+        // For drag: {{"source": {{"x": N, "y": N}}, "target": {{"x": N, "y": N}}}}
+        // For text: {{"text": "ABCD"}}
+        // For slide: {{"distance": N}}
+        // For click: {{"clicks": [{{"x": N, "y": N}}]}}
+        // For checkbox: {{"x": N, "y": N}}
+    }}
+}}
+
+If you cannot solve it:
+{{"solved": false, "reason": "description of why"}}"""
+
+
+def _build_bounding_box_prompt(detection) -> str:
+    """Spezial-Prompt für Gemini's native bounding-box Fähigkeit."""
+    ctype = detection.captcha_type
+    dom_hint = detection.dom_hint or ""
+
+    return f"""Analyze this CAPTCHA image. Type: {ctype}. Hint: {dom_hint}
+
+Your task is to identify interactive elements and their bounding boxes.
+
+For DRAG puzzles: Find the draggable element and drop zone.
+For SLIDER puzzles: Find the slider handle and the gap position.
+For CLICK puzzles: Find all elements that should be clicked.
+
+Return JSON with bounding boxes:
+{{
+    "elements": [
+        {{"label": "draggable", "bbox": [x1, y1, x2, y2]}},
+        {{"label": "dropzone", "bbox": [x1, y1, x2, y2]}}
+    ],
+    "action": "drag" | "click" | "slide",
+    "solved": true
+}}
+
+If unsolvable: {{"solved": false, "reason": "why"}}"""
+
+
+# ── GATEWAY CLIENT ─────────────────────────────────────────────────────────
+
+class GatewaySolver:
+    """Vercel AI Gateway Solver für Vision-basierte Captchas.
+
+    Nutzt Vercel AI Gateway mit:
+    - Primary: Gemini 3.1 Flash Image (schnell, native grounding)
+    - Fallback: Claude Opus 4.7 (stärkeres reasoning)
+
+    Graceful skip wenn AI_GATEWAY_API_KEY nicht gesetzt.
+    """
+
+    def __init__(self, api_key: str = None):
+        self.api_key = api_key or os.getenv("AI_GATEWAY_API_KEY")
+        self._available = bool(self.api_key)
+        self.consecutive_failures = 0
+
+        if not self._available:
+            logger.warning(
+                "AI_GATEWAY_API_KEY not set — GatewaySolver will be skipped in fallback chain"
+            )
+
+    @property
+    def available(self) -> bool:
+        """Check if solver is available (API key set + not circuit-broken)."""
+        return self._available and self.consecutive_failures < 3
+
+    def _record_failure(self, reason: str):
+        self.consecutive_failures += 1
+        logger.warning("Gateway failure: %s (count: %d)", reason, self.consecutive_failures)
+        if self.consecutive_failures >= 3:
+            logger.error("Gateway circuit breaker OPEN")
+
+    def _record_success(self):
+        if self.consecutive_failures > 0:
+            logger.info("Gateway success: resetting failure count")
+        self.consecutive_failures = 0
+
+    def _call_gateway_api(self, model: str, prompt: str, image_b64: str) -> Optional[str]:
+        """Call Vercel AI Gateway with vision request.
+
+        Args:
+            model: Model string (e.g. "google/gemini-3.1-flash-image-preview")
+            prompt: Text prompt
+            image_b64: Base64-encoded PNG image
+
+        Returns:
+            Raw model response text or None on failure
+        """
+        if not self.api_key:
+            return None
+
+        # Build request payload (OpenAI-compatible format)
+        payload = {
+            "model": model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/png;base64,{image_b64}"}
+                        }
+                    ]
+                }
+            ],
+            "max_tokens": MAX_TOKENS,
+            "temperature": 0.1,
+        }
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+
+        for attempt in range(1, RETRIES + 1):
+            try:
+                req = Request(
+                    f"{GATEWAY_BASE_URL}/chat/completions",
+                    data=json.dumps(payload).encode("utf-8"),
+                    headers=headers,
+                    method="POST",
+                )
+                with urlopen(req, timeout=TIMEOUT_S) as resp:
+                    data = json.loads(resp.read().decode("utf-8"))
+                    content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+                    self._record_success()
+                    return content
+            except HTTPError as e:
+                self._record_failure(f"http_{e.code}: {e.reason}")
+                if e.code == 429 and attempt < RETRIES:
+                    time.sleep(5)
+                    continue
+                if e.code >= 500 and attempt < RETRIES:
+                    time.sleep(2 ** attempt)
+                    continue
+            except URLError as e:
+                self._record_failure(f"network: {e.reason}")
+                if attempt < RETRIES:
+                    time.sleep(2 ** attempt)
+                    continue
+            except Exception as e:
+                self._record_failure(f"unknown: {e}")
+                break
+        return None
+
+    def _parse_json_response(self, raw: str) -> Optional[dict]:
+        """Parse JSON from model response."""
+        if not raw:
+            return None
+        raw = raw.strip()
+        # Strip markdown
+        if raw.startswith("```"):
+            lines = raw.split("\n")
+            lines = [l for l in lines if not l.strip().startswith("```")]
+            raw = "\n".join(lines)
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+        # Extract JSON object
+        match = re.search(r"\{.*\}", raw, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group(0))
+            except json.JSONDecodeError:
+                pass
+        return None
+
+    def solve(self, cdp, detection) -> CaptchaResult:
+        """Hauptmethode: Löst Captcha via Vercel AI Gateway.
+
+        Versucht zuerst Gemini 3.1 Flash Image, dann Claude Opus 4.7.
+
+        Args:
+            cdp: CDPConnection instance
+            detection: CaptchaDetection mit captcha_type und dom_hint
+
+        Returns:
+            CaptchaResult mit solved=True/False und Details
+        """
+        t0 = time.time()
+        ctype = detection.captcha_type
+
+        # Check support
+        if ctype not in SUPPORTED_TYPES:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="unsupported_type",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Check availability (graceful skip if no API key)
+        if not self.available:
+            reason = "api_key_not_set" if not self.api_key else "circuit_breaker_open"
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason=reason,
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Capture screenshot
+        screenshot = _capture_screenshot_b64(cdp, detection.frame_id)
+        if not screenshot:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="screenshot_failed",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Try Gemini first (fast, native bounding-box)
+        logger.info("Trying %s for %s", GATEWAY_PRIMARY_MODEL, ctype)
+        prompt = _build_bounding_box_prompt(detection)
+        raw_response = self._call_gateway_api(GATEWAY_PRIMARY_MODEL, prompt, screenshot)
+
+        parsed = self._parse_json_response(raw_response) if raw_response else None
+        model_used = GATEWAY_PRIMARY_MODEL
+
+        # If Gemini failed, try Claude
+        if not parsed or not parsed.get("solved", False):
+            logger.info("Gemini failed, trying %s", GATEWAY_FALLBACK_MODEL)
+            prompt = _build_unified_prompt(detection)
+            raw_response = self._call_gateway_api(GATEWAY_FALLBACK_MODEL, prompt, screenshot)
+            parsed = self._parse_json_response(raw_response) if raw_response else None
+            model_used = GATEWAY_FALLBACK_MODEL
+
+        # Check if we got a valid response
+        if not parsed:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="both_models_failed",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        if not parsed.get("solved", False):
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason=parsed.get("reason", "model_returned_unsolved"),
+                elapsed_ms=(time.time() - t0) * 1000,
+                extra={"model": model_used},
+            )
+
+        # Execute action based on response
+        try:
+            success = self._execute_action(cdp, parsed)
+        except Exception as e:
+            logger.error("Action execution failed: %s", e)
+            success = False
+
+        return CaptchaResult(
+            solved=success,
+            captcha_type=ctype,
+            reason="ok" if success else "execution_failed",
+            elapsed_ms=(time.time() - t0) * 1000,
+            extra={"model": model_used, "response": parsed},
+        )
+
+    def _execute_action(self, cdp, parsed: dict) -> bool:
+        """Execute action based on parsed model response."""
+        action_type = parsed.get("action_type") or parsed.get("action", "")
+        data = parsed.get("data", parsed)
+
+        if action_type == "drag":
+            return self._execute_drag(cdp, data)
+        elif action_type == "text":
+            return self._execute_text(cdp, data)
+        elif action_type == "slide":
+            return self._execute_slide(cdp, data)
+        elif action_type in ("click", "checkbox"):
+            return self._execute_click(cdp, data)
+        elif "elements" in parsed:
+            # Bounding-box response from Gemini
+            return self._execute_from_bboxes(cdp, parsed)
+        else:
+            logger.warning("Unknown action type: %s", action_type)
+            return False
+
+    def _execute_drag(self, cdp, data: dict) -> bool:
+        """Execute drag action."""
+        source = data.get("source", {})
+        target = data.get("target", {})
+        sx, sy = source.get("x"), source.get("y")
+        tx, ty = target.get("x"), target.get("y")
+        if None in (sx, sy, tx, ty):
+            return False
+
+        cdp.call_result("Input.dispatchMouseEvent", {
+            "type": "mousePressed", "x": sx, "y": sy,
+            "button": "left", "clickCount": 1
+        })
+        time.sleep(0.05)
+
+        steps = 10
+        for i in range(1, steps + 1):
+            t = i / steps
+            px = sx + (tx - sx) * t
+            py = sy + (ty - sy) * t
+            cdp.call_result("Input.dispatchMouseEvent", {
+                "type": "mouseMoved", "x": px, "y": py, "button": "left"
+            })
+            time.sleep(0.03)
+
+        cdp.call_result("Input.dispatchMouseEvent", {
+            "type": "mouseReleased", "x": tx, "y": ty,
+            "button": "left", "clickCount": 1
+        })
+        return True
+
+    def _execute_text(self, cdp, data: dict) -> bool:
+        """Execute text input."""
+        text = data.get("text", "")
+        if not text:
+            return False
+
+        js = (
+            f"(function(){{"
+            f"var inp=document.querySelector('input[type=text],input:not([type])');"
+            f"if(!inp)return false;"
+            f"inp.focus();"
+            f"inp.value='{text}';"
+            f"inp.dispatchEvent(new Event('input',{{bubbles:true}}));"
+            f"return true;"
+            f"}})()"
+        )
+        resp = cdp.call_result("Runtime.evaluate", {"expression": js})
+        return resp.get("result", {}).get("value", False)
+
+    def _execute_slide(self, cdp, data: dict) -> bool:
+        """Execute slider action."""
+        distance = data.get("distance", 0)
+        if not distance:
+            return False
+
+        js = (
+            "(function(){"
+            "var s=document.querySelector('.geetest_slider_button,.slider-handle,[class*=slider]');"
+            "if(!s)return null;"
+            "var r=s.getBoundingClientRect();"
+            "return {x:r.left+r.width/2,y:r.top+r.height/2};"
+            "})()"
+        )
+        resp = cdp.call_result("Runtime.evaluate", {"expression": js})
+        pos = resp.get("result", {}).get("value")
+        if not pos:
+            return False
+
+        sx, sy = pos["x"], pos["y"]
+        tx = sx + distance
+
+        cdp.call_result("Input.dispatchMouseEvent", {
+            "type": "mousePressed", "x": sx, "y": sy,
+            "button": "left", "clickCount": 1
+        })
+
+        steps = 15
+        for i in range(1, steps + 1):
+            t = i / steps
+            ease = 1 - (1 - t) ** 3
+            px = sx + (tx - sx) * ease
+            cdp.call_result("Input.dispatchMouseEvent", {
+                "type": "mouseMoved", "x": px, "y": sy, "button": "left"
+            })
+            time.sleep(0.02)
+
+        cdp.call_result("Input.dispatchMouseEvent", {
+            "type": "mouseReleased", "x": tx, "y": sy,
+            "button": "left", "clickCount": 1
+        })
+        return True
+
+    def _execute_click(self, cdp, data: dict) -> bool:
+        """Execute click(s)."""
+        clicks = data.get("clicks", [])
+        if not clicks:
+            # Single click (checkbox)
+            x, y = data.get("x"), data.get("y")
+            if x is not None and y is not None:
+                clicks = [{"x": x, "y": y}]
+
+        if not clicks:
+            return False
+
+        for click in clicks:
+            x, y = click.get("x"), click.get("y")
+            if x is None or y is None:
+                continue
+            cdp.call_result("Input.dispatchMouseEvent", {
+                "type": "mousePressed", "x": x, "y": y,
+                "button": "left", "clickCount": 1
+            })
+            time.sleep(0.05)
+            cdp.call_result("Input.dispatchMouseEvent", {
+                "type": "mouseReleased", "x": x, "y": y,
+                "button": "left", "clickCount": 1
+            })
+            time.sleep(0.2)
+        return True
+
+    def _execute_from_bboxes(self, cdp, parsed: dict) -> bool:
+        """Execute action from Gemini's bounding-box response."""
+        elements = parsed.get("elements", [])
+        action = parsed.get("action", "click")
+
+        if action == "drag" and len(elements) >= 2:
+            source = next((e for e in elements if "drag" in e.get("label", "").lower()), None)
+            target = next((e for e in elements if "drop" in e.get("label", "").lower() or
+                          "zone" in e.get("label", "").lower()), None)
+            if source and target:
+                sb = source["bbox"]
+                tb = target["bbox"]
+                return self._execute_drag(cdp, {
+                    "source": {"x": (sb[0] + sb[2]) / 2, "y": (sb[1] + sb[3]) / 2},
+                    "target": {"x": (tb[0] + tb[2]) / 2, "y": (tb[1] + tb[3]) / 2},
+                })
+
+        elif action == "click":
+            clicks = []
+            for elem in elements:
+                bbox = elem.get("bbox", [])
+                if len(bbox) == 4:
+                    clicks.append({
+                        "x": (bbox[0] + bbox[2]) / 2,
+                        "y": (bbox[1] + bbox[3]) / 2,
+                    })
+            if clicks:
+                return self._execute_click(cdp, {"clicks": clicks})
+
+        return False
+
+
+# ── SINGLETON + PUBLIC API ─────────────────────────────────────────────────
+
+_solver_instance: Optional[GatewaySolver] = None
+
+
+def get_solver() -> GatewaySolver:
+    """Singleton-Accessor für GatewaySolver."""
+    global _solver_instance
+    if _solver_instance is None:
+        _solver_instance = GatewaySolver()
+    return _solver_instance
+
+
+def solve(cdp, detection) -> CaptchaResult:
+    """Public API: Löst Captcha via Vercel AI Gateway.
+
+    Versucht zuerst google/gemini-3.1-flash-image-preview,
+    dann anthropic/claude-opus-4.7 bei Fehler.
+
+    Graceful skip wenn AI_GATEWAY_API_KEY nicht gesetzt.
+
+    Args:
+        cdp: CDPConnection instance
+        detection: CaptchaDetection mit captcha_type und dom_hint
+
+    Returns:
+        CaptchaResult mit solved, captcha_type, reason, elapsed_ms, extra
+    """
+    return get_solver().solve(cdp, detection)

--- a/survey-cli/survey/captcha/nim_secondary_solver.py
+++ b/survey-cli/survey/captcha/nim_secondary_solver.py
@@ -1,0 +1,566 @@
+"""================================================================================
+NIM SECONDARY SOLVER — Qwen2.5-VL-72B Vision Model als Fallback für Captchas
+================================================================================
+
+MODUL-KONZEPT (SR-138, 2026-05-12):
+    Dieses Modul implementiert den zweiten Schritt der Captcha-Fallback-Chain.
+    Wenn der primäre NIM-Solver (Nemotron-3-Nano-Omni) fehlschlägt, wird hier
+    ein alternatives Vision-Modell auf NVIDIA NIM verwendet.
+
+WARUM EIN ZWEITES NIM-MODELL?
+    - Unterschiedliche Modelle haben unterschiedliche Stärken bei Captchas
+    - Qwen2.5-VL-72B ist state-of-the-art für Vision-Grounding (2026)
+    - Kostenlos auf NVIDIA NIM verfügbar
+    - Reduziert modellspezifische Fehler durch Diversität
+
+UNTERSTÜTZTE CAPTCHA-TYPEN:
+    ✅ angular_drag_drop — PureSpectrum Drag-Drop Puzzles
+    ✅ visual_text — Text-basierte Captchas mit Bild
+    ✅ geetest_v4 — GeeTest Slider/Click-Captchas
+    ❌ hcaptcha, recaptcha — benötigen Token-basierte Lösung (siehe audio_solver)
+
+ARCHITEKTUR:
+    1. Screenshot des Captcha-Bereichs via CDP
+    2. Vision-Prompt an Qwen2.5-VL-72B für Koordinaten/Text-Extraktion
+    3. Ausführung der erkannten Aktion (Klick, Drag, Text-Eingabe)
+
+API (konform mit Solver-Interface aus captcha_router):
+    solve(cdp, detection) -> CaptchaResult
+
+NVIDIA NIM ENDPOINT:
+    Model: nvidia/qwen2.5-vl-72b-instruct
+    Docs: https://build.nvidia.com/qwen/qwen2_5-vl-72b-instruct
+
+Module Status: NEW (SR-138, 2026-05-12)
+================================================================================
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from openai import OpenAI, APIConnectionError, APITimeoutError, RateLimitError
+
+logger = logging.getLogger("nim_secondary_solver")
+
+# ── CONFIG ─────────────────────────────────────────────────────────────────
+
+NIM_SECONDARY_MODEL = "nvidia/qwen2.5-vl-72b-instruct"
+NIM_BASE_URL = "https://integrate.api.nvidia.com/v1"
+MAX_TOKENS = 512
+TIMEOUT_S = 30
+RETRIES = 2
+
+# Captcha-Typen die dieser Solver unterstützt (Vision-basiert)
+SUPPORTED_TYPES = frozenset({
+    "angular_drag_drop",
+    "visual_text",
+    "geetest_v4",
+    "geetest_v3",
+    "slider",
+    "click_captcha",
+})
+
+# ── RESULT DATACLASS ───────────────────────────────────────────────────────
+
+@dataclass
+class CaptchaResult:
+    """Ergebnis eines Captcha-Lösungsversuchs."""
+    solved: bool
+    captcha_type: str = ""
+    token: str = ""
+    elapsed_ms: float = 0.0
+    reason: str = "ok"
+    extra: dict[str, Any] = None
+
+    def __post_init__(self):
+        if self.extra is None:
+            self.extra = {}
+
+
+# ── SCREENSHOT CAPTURE ─────────────────────────────────────────────────────
+
+def _capture_screenshot_b64(cdp, frame_id: str = "") -> Optional[str]:
+    """Capture full-page oder Frame-Screenshot als Base64 PNG.
+
+    Args:
+        cdp: CDPConnection instance
+        frame_id: Optional Frame-ID für iframe-Captchas
+
+    Returns:
+        Base64-encoded PNG string oder None bei Fehler
+    """
+    try:
+        params = {"format": "png", "quality": 80}
+        resp = cdp.call_result("Page.captureScreenshot", params)
+        return resp.get("data")
+    except Exception as e:
+        logger.warning("Screenshot capture failed: %s", e)
+        return None
+
+
+# ── VISION PROMPT BUILDERS ─────────────────────────────────────────────────
+
+def _build_drag_drop_prompt(detection) -> str:
+    """Prompt für Angular CDK Drag-Drop Puzzles."""
+    target = detection.dom_hint.replace("target=", "") if detection.dom_hint else "?"
+    return f"""You are solving a drag-and-drop CAPTCHA puzzle.
+
+TASK: Find the number "{target}" in the image and determine its drag coordinates.
+
+The puzzle shows:
+- Multiple draggable number images
+- A drop zone where one number should be placed
+- Instructions saying "Please drag the number {target}"
+
+ANALYZE the image and provide:
+1. The bounding box of the number {target} (source)
+2. The bounding box of the drop zone (target)
+
+OUTPUT FORMAT (JSON only, no markdown):
+{{"source": {{"x": <center_x>, "y": <center_y>}}, "target": {{"x": <center_x>, "y": <center_y>}}, "found": true}}
+
+If you cannot find the number, return:
+{{"found": false, "reason": "number not visible"}}"""
+
+
+def _build_visual_text_prompt(detection) -> str:
+    """Prompt für Visual-Text Captchas."""
+    return """You are solving a text-based image CAPTCHA.
+
+TASK: Read the distorted text shown in the CAPTCHA image.
+
+The image contains:
+- Distorted, warped, or noisy text characters
+- Usually 4-6 alphanumeric characters
+- May have lines, dots, or color noise as obfuscation
+
+ANALYZE the image and provide:
+1. The exact characters you can read
+
+OUTPUT FORMAT (JSON only, no markdown):
+{"text": "<characters>", "confidence": <0.0-1.0>}
+
+If unreadable, return:
+{"text": "", "confidence": 0.0, "reason": "unreadable"}"""
+
+
+def _build_slider_prompt() -> str:
+    """Prompt für Slider-Captchas (GeeTest etc.)."""
+    return """You are solving a slider CAPTCHA puzzle.
+
+TASK: Find the puzzle piece and the gap where it should be placed.
+
+The image shows:
+- A background image with a missing puzzle piece (gap/hole)
+- A separate puzzle piece that needs to slide into the gap
+
+ANALYZE the image and provide:
+1. The X-coordinate of the gap (target position)
+2. The current X-coordinate of the slider piece
+3. The distance to slide
+
+OUTPUT FORMAT (JSON only, no markdown):
+{"gap_x": <x_coordinate>, "slider_x": <start_x>, "distance": <pixels_to_slide>, "found": true}
+
+If you cannot determine the gap position, return:
+{"found": false, "reason": "gap not visible"}"""
+
+
+def _build_click_captcha_prompt() -> str:
+    """Prompt für Click-basierte Captchas."""
+    return """You are solving a click-based CAPTCHA.
+
+TASK: Identify which elements need to be clicked based on the instruction.
+
+Common instructions:
+- "Click on all traffic lights"
+- "Select all images with crosswalks"
+- "Click the objects in order: cat, dog, bird"
+
+ANALYZE the image and provide:
+1. List of coordinates to click
+2. Order of clicks if specified
+
+OUTPUT FORMAT (JSON only, no markdown):
+{"clicks": [{"x": <x>, "y": <y>, "label": "<what>"}], "found": true}
+
+If unclear what to click, return:
+{"found": false, "reason": "instruction unclear"}"""
+
+
+# ── NIM CLIENT ─────────────────────────────────────────────────────────────
+
+class NimSecondarySolver:
+    """NVIDIA NIM Qwen2.5-VL Solver für Vision-basierte Captchas.
+
+    Nutzt das Qwen2.5-VL-72B Modell auf NVIDIA NIM für:
+    - Koordinaten-Extraktion (Drag-Drop, Slider)
+    - Text-Erkennung (Visual-Text Captchas)
+    - Click-Target-Identifikation
+
+    Circuit-Breaker und Retry-Pattern analog zu nim.py.
+    """
+
+    def __init__(self, api_key: str = None):
+        self.api_key = api_key or os.getenv("NVIDIA_API_KEY")
+        self.client = None
+        if self.api_key:
+            self.client = OpenAI(api_key=self.api_key, base_url=NIM_BASE_URL)
+        self._available = self.client is not None
+        self.consecutive_failures = 0
+
+    @property
+    def available(self) -> bool:
+        return self._available and self.consecutive_failures < 3
+
+    def _record_failure(self, reason: str):
+        self.consecutive_failures += 1
+        logger.warning("NimSecondary failure: %s (count: %d)", reason, self.consecutive_failures)
+        if self.consecutive_failures >= 3:
+            self._available = False
+
+    def _record_success(self):
+        self.consecutive_failures = 0
+        self._available = True
+
+    def _call_vision_api(self, prompt: str, image_b64: str) -> Optional[str]:
+        """Call NIM Vision API with image + prompt.
+
+        Args:
+            prompt: Text prompt describing the task
+            image_b64: Base64-encoded PNG image
+
+        Returns:
+            Raw model response text or None on failure
+        """
+        if not self.client:
+            return None
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{image_b64}"}
+                    }
+                ]
+            }
+        ]
+
+        for attempt in range(1, RETRIES + 1):
+            try:
+                response = self.client.chat.completions.create(
+                    model=NIM_SECONDARY_MODEL,
+                    messages=messages,
+                    max_tokens=MAX_TOKENS,
+                    temperature=0.1,
+                )
+                self._record_success()
+                return response.choices[0].message.content
+            except (APIConnectionError, APITimeoutError) as e:
+                self._record_failure(f"network: {e}")
+                if attempt < RETRIES:
+                    time.sleep(2 ** attempt)
+            except RateLimitError as e:
+                self._record_failure(f"rate_limit: {e}")
+                if attempt < RETRIES:
+                    time.sleep(5)
+            except Exception as e:
+                self._record_failure(f"unknown: {e}")
+                break
+        return None
+
+    def _parse_json_response(self, raw: str) -> Optional[dict]:
+        """Parse JSON from model response, handling markdown wrapping."""
+        if not raw:
+            return None
+        raw = raw.strip()
+        # Strip markdown code blocks
+        if raw.startswith("```"):
+            lines = raw.split("\n")
+            lines = [l for l in lines if not l.strip().startswith("```")]
+            raw = "\n".join(lines)
+        # Try direct parse
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+        # Try extracting JSON object
+        match = re.search(r"\{[^{}]*\}", raw, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group(0))
+            except json.JSONDecodeError:
+                pass
+        return None
+
+    def solve(self, cdp, detection) -> CaptchaResult:
+        """Hauptmethode: Löst Captcha via NIM Qwen2.5-VL Vision Model.
+
+        Args:
+            cdp: CDPConnection instance
+            detection: CaptchaDetection mit captcha_type und dom_hint
+
+        Returns:
+            CaptchaResult mit solved=True/False und Details
+        """
+        t0 = time.time()
+        ctype = detection.captcha_type
+
+        # Check support
+        if ctype not in SUPPORTED_TYPES:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="unsupported_type",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Check availability
+        if not self.available:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="nim_secondary_unavailable",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Capture screenshot
+        screenshot = _capture_screenshot_b64(cdp, detection.frame_id)
+        if not screenshot:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="screenshot_failed",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Build type-specific prompt
+        if ctype == "angular_drag_drop":
+            prompt = _build_drag_drop_prompt(detection)
+        elif ctype == "visual_text":
+            prompt = _build_visual_text_prompt(detection)
+        elif ctype in ("geetest_v4", "geetest_v3", "slider"):
+            prompt = _build_slider_prompt()
+        elif ctype == "click_captcha":
+            prompt = _build_click_captcha_prompt()
+        else:
+            prompt = _build_click_captcha_prompt()  # Generic fallback
+
+        # Call Vision API
+        raw_response = self._call_vision_api(prompt, screenshot)
+        if not raw_response:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="nim_api_failed",
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Parse response
+        parsed = self._parse_json_response(raw_response)
+        if not parsed:
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason="parse_failed",
+                elapsed_ms=(time.time() - t0) * 1000,
+                extra={"raw": raw_response[:200]},
+            )
+
+        # Check if model found the target
+        if not parsed.get("found", True):
+            return CaptchaResult(
+                solved=False,
+                captcha_type=ctype,
+                reason=parsed.get("reason", "not_found"),
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+        # Execute action based on type
+        try:
+            if ctype == "angular_drag_drop":
+                success = self._execute_drag_drop(cdp, parsed)
+            elif ctype == "visual_text":
+                success = self._execute_text_input(cdp, parsed)
+            elif ctype in ("geetest_v4", "geetest_v3", "slider"):
+                success = self._execute_slider(cdp, parsed)
+            elif ctype == "click_captcha":
+                success = self._execute_clicks(cdp, parsed)
+            else:
+                success = False
+        except Exception as e:
+            logger.error("Action execution failed: %s", e)
+            success = False
+
+        return CaptchaResult(
+            solved=success,
+            captcha_type=ctype,
+            reason="ok" if success else "execution_failed",
+            elapsed_ms=(time.time() - t0) * 1000,
+            extra={"model": NIM_SECONDARY_MODEL, "response": parsed},
+        )
+
+    def _execute_drag_drop(self, cdp, parsed: dict) -> bool:
+        """Execute drag-drop action based on parsed coordinates."""
+        source = parsed.get("source", {})
+        target = parsed.get("target", {})
+        sx, sy = source.get("x"), source.get("y")
+        tx, ty = target.get("x"), target.get("y")
+        if None in (sx, sy, tx, ty):
+            return False
+
+        # Mouse down at source
+        cdp.call_result("Input.dispatchMouseEvent", {
+            "type": "mousePressed", "x": sx, "y": sy,
+            "button": "left", "clickCount": 1
+        })
+        time.sleep(0.05)
+
+        # Move in steps
+        steps = 10
+        for i in range(1, steps + 1):
+            t = i / steps
+            px = sx + (tx - sx) * t
+            py = sy + (ty - sy) * t
+            cdp.call_result("Input.dispatchMouseEvent", {
+                "type": "mouseMoved", "x": px, "y": py, "button": "left"
+            })
+            time.sleep(0.03)
+
+        # Mouse up at target
+        cdp.call_result("Input.dispatchMouseEvent", {
+            "type": "mouseReleased", "x": tx, "y": ty,
+            "button": "left", "clickCount": 1
+        })
+        time.sleep(0.3)
+        return True
+
+    def _execute_text_input(self, cdp, parsed: dict) -> bool:
+        """Execute text input for visual-text captcha."""
+        text = parsed.get("text", "")
+        if not text:
+            return False
+
+        # Find input field and type
+        js = (
+            f"(function(){{"
+            f"var inp=document.querySelector('input[type=text],input:not([type])');"
+            f"if(!inp)return false;"
+            f"inp.focus();"
+            f"inp.value='{text}';"
+            f"inp.dispatchEvent(new Event('input',{{bubbles:true}}));"
+            f"return true;"
+            f"}})()"
+        )
+        resp = cdp.call_result("Runtime.evaluate", {"expression": js})
+        return resp.get("result", {}).get("value", False)
+
+    def _execute_slider(self, cdp, parsed: dict) -> bool:
+        """Execute slider drag for GeeTest-style captchas."""
+        distance = parsed.get("distance", 0)
+        if not distance:
+            return False
+
+        # Find slider handle
+        js = (
+            "(function(){"
+            "var s=document.querySelector('.geetest_slider_button,.slider-handle,[class*=slider]');"
+            "if(!s)return null;"
+            "var r=s.getBoundingClientRect();"
+            "return {x:r.left+r.width/2,y:r.top+r.height/2};"
+            "})()"
+        )
+        resp = cdp.call_result("Runtime.evaluate", {"expression": js})
+        pos = resp.get("result", {}).get("value")
+        if not pos:
+            return False
+
+        sx, sy = pos["x"], pos["y"]
+        tx = sx + distance
+
+        # Execute slide
+        cdp.call_result("Input.dispatchMouseEvent", {
+            "type": "mousePressed", "x": sx, "y": sy,
+            "button": "left", "clickCount": 1
+        })
+        time.sleep(0.1)
+
+        # Slide with acceleration curve
+        steps = 15
+        for i in range(1, steps + 1):
+            t = i / steps
+            # Ease-out curve
+            ease = 1 - (1 - t) ** 3
+            px = sx + (tx - sx) * ease
+            cdp.call_result("Input.dispatchMouseEvent", {
+                "type": "mouseMoved", "x": px, "y": sy, "button": "left"
+            })
+            time.sleep(0.02)
+
+        cdp.call_result("Input.dispatchMouseEvent", {
+            "type": "mouseReleased", "x": tx, "y": sy,
+            "button": "left", "clickCount": 1
+        })
+        return True
+
+    def _execute_clicks(self, cdp, parsed: dict) -> bool:
+        """Execute click sequence for click-based captchas."""
+        clicks = parsed.get("clicks", [])
+        if not clicks:
+            return False
+
+        for click in clicks:
+            x, y = click.get("x"), click.get("y")
+            if x is None or y is None:
+                continue
+            cdp.call_result("Input.dispatchMouseEvent", {
+                "type": "mousePressed", "x": x, "y": y,
+                "button": "left", "clickCount": 1
+            })
+            time.sleep(0.05)
+            cdp.call_result("Input.dispatchMouseEvent", {
+                "type": "mouseReleased", "x": x, "y": y,
+                "button": "left", "clickCount": 1
+            })
+            time.sleep(0.2)
+        return True
+
+
+# ── SINGLETON + PUBLIC API ─────────────────────────────────────────────────
+
+_solver_instance: Optional[NimSecondarySolver] = None
+
+
+def get_solver() -> NimSecondarySolver:
+    """Singleton-Accessor für NimSecondarySolver."""
+    global _solver_instance
+    if _solver_instance is None:
+        _solver_instance = NimSecondarySolver()
+    return _solver_instance
+
+
+def solve(cdp, detection) -> CaptchaResult:
+    """Public API: Löst Captcha via NIM Qwen2.5-VL-72B.
+
+    Konform mit Solver-Interface aus captcha_router:
+        solve(cdp, detection) -> CaptchaResult
+
+    Args:
+        cdp: CDPConnection instance
+        detection: CaptchaDetection mit captcha_type und dom_hint
+
+    Returns:
+        CaptchaResult mit solved, captcha_type, reason, elapsed_ms, extra
+    """
+    return get_solver().solve(cdp, detection)

--- a/survey-cli/tests/test_captcha_fallback.py
+++ b/survey-cli/tests/test_captcha_fallback.py
@@ -1,0 +1,575 @@
+"""================================================================================
+CAPTCHA FALLBACK CHAIN TESTS — Unit Tests mit Mocked HTTP Layers (SR-138)
+================================================================================
+
+Test Coverage (18+ Tests gemäß Acceptance Criteria):
+
+NimSecondary (3 Tests):
+    - test_nim_secondary_success
+    - test_nim_secondary_api_error
+    - test_nim_secondary_unsupported_type
+
+Gateway (5 Tests):
+    - test_gateway_gemini_success
+    - test_gateway_gemini_fail_claude_success
+    - test_gateway_both_fail
+    - test_gateway_no_api_key_graceful_skip
+    - test_gateway_coords_extraction
+
+Audio (3 Tests):
+    - test_audio_recaptcha_success
+    - test_audio_hcaptcha_success
+    - test_audio_parakeet_error
+
+FallbackChain (4 Tests):
+    - test_chain_success_step_1
+    - test_chain_step1_fail_step2_succeeds
+    - test_chain_all_vision_fail_audio_succeeds
+    - test_chain_all_fail_handoff
+
+Logging (3 Tests):
+    - test_jsonl_shape
+    - test_step_trace_correctness
+    - test_screenshot_encoding
+
+Module Status: NEW (SR-138, 2026-05-12)
+================================================================================
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+from unittest import TestCase
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+
+# ── MOCK FIXTURES ──────────────────────────────────────────────────────────
+
+@dataclass
+class MockCaptchaDetection:
+    """Mock CaptchaDetection für Tests."""
+    captcha_type: str
+    frame_id: str = ""
+    frame_url: str = ""
+    dom_hint: str = ""
+
+
+@dataclass
+class MockCaptchaResult:
+    """Mock CaptchaResult für Tests."""
+    solved: bool
+    captcha_type: str = ""
+    token: str = ""
+    elapsed_ms: float = 0.0
+    reason: str = "ok"
+    extra: dict = None
+
+    def __post_init__(self):
+        if self.extra is None:
+            self.extra = {}
+
+
+class MockCDPConnection:
+    """Mock CDP Connection für Tests."""
+
+    def __init__(self, screenshot_b64: str = None, eval_results: dict = None):
+        self._screenshot = screenshot_b64 or base64.b64encode(b"fake_png_data").decode()
+        self._eval_results = eval_results or {}
+        self.calls = []
+
+    def call_result(self, method: str, params: dict = None) -> dict:
+        self.calls.append((method, params))
+
+        if method == "Page.captureScreenshot":
+            return {"data": self._screenshot}
+        elif method == "Runtime.evaluate":
+            expr = params.get("expression", "")
+            for key, value in self._eval_results.items():
+                if key in expr:
+                    return {"result": {"value": value}}
+            return {"result": {"value": None}}
+        elif method == "Input.dispatchMouseEvent":
+            return {}
+        return {}
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# NIM SECONDARY SOLVER TESTS (3)
+# ══════════════════════════════════════════════════════════════════════════
+
+class TestNimSecondarySolver:
+    """Tests für nim_secondary_solver.py."""
+
+    def test_nim_secondary_success(self):
+        """Test successful solve with NIM Qwen2.5-VL."""
+        from survey.captcha.nim_secondary_solver import NimSecondarySolver, CaptchaResult
+
+        solver = NimSecondarySolver(api_key="test_key")
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(
+            captcha_type="angular_drag_drop",
+            dom_hint="target=28"
+        )
+
+        # Mock API response
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps({
+            "found": True,
+            "source": {"x": 100, "y": 200},
+            "target": {"x": 300, "y": 200}
+        })
+
+        with patch.object(solver, "_call_vision_api", return_value=mock_response.choices[0].message.content):
+            result = solver.solve(cdp, detection)
+
+        assert result.solved is True
+        assert result.captcha_type == "angular_drag_drop"
+        assert result.reason == "ok"
+
+    def test_nim_secondary_api_error(self):
+        """Test handling of NIM API errors."""
+        from survey.captcha.nim_secondary_solver import NimSecondarySolver
+
+        solver = NimSecondarySolver(api_key="test_key")
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="angular_drag_drop")
+
+        # Mock API failure
+        with patch.object(solver, "_call_vision_api", return_value=None):
+            result = solver.solve(cdp, detection)
+
+        assert result.solved is False
+        assert result.reason == "nim_api_failed"
+
+    def test_nim_secondary_unsupported_type(self):
+        """Test that unsupported captcha types are rejected."""
+        from survey.captcha.nim_secondary_solver import NimSecondarySolver
+
+        solver = NimSecondarySolver(api_key="test_key")
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="unknown_type")
+
+        result = solver.solve(cdp, detection)
+
+        assert result.solved is False
+        assert result.reason == "unsupported_type"
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# GATEWAY SOLVER TESTS (5)
+# ══════════════════════════════════════════════════════════════════════════
+
+class TestGatewaySolver:
+    """Tests für gateway_solver.py."""
+
+    def test_gateway_gemini_success(self):
+        """Test successful solve with Gemini 3.1 Flash Image."""
+        from survey.captcha.gateway_solver import GatewaySolver
+
+        solver = GatewaySolver(api_key="test_gateway_key")
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(
+            captcha_type="angular_drag_drop",
+            dom_hint="target=42"
+        )
+
+        gemini_response = json.dumps({
+            "elements": [
+                {"label": "draggable", "bbox": [100, 200, 150, 250]},
+                {"label": "dropzone", "bbox": [300, 200, 350, 250]}
+            ],
+            "action": "drag",
+            "solved": True
+        })
+
+        with patch.object(solver, "_call_gateway_api", return_value=gemini_response):
+            result = solver.solve(cdp, detection)
+
+        assert result.solved is True
+        assert "gemini" in result.extra.get("model", "").lower()
+
+    def test_gateway_gemini_fail_claude_success(self):
+        """Test fallback to Claude when Gemini fails."""
+        from survey.captcha.gateway_solver import GatewaySolver, GATEWAY_PRIMARY_MODEL, GATEWAY_FALLBACK_MODEL
+
+        solver = GatewaySolver(api_key="test_gateway_key")
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="visual_text")
+
+        call_count = [0]
+
+        def mock_call(model, prompt, image):
+            call_count[0] += 1
+            if model == GATEWAY_PRIMARY_MODEL:
+                return json.dumps({"solved": False, "reason": "gemini_failed"})
+            else:
+                return json.dumps({
+                    "action_type": "text",
+                    "solved": True,
+                    "data": {"text": "ABC123"}
+                })
+
+        with patch.object(solver, "_call_gateway_api", side_effect=mock_call):
+            result = solver.solve(cdp, detection)
+
+        assert result.solved is True
+        assert "claude" in result.extra.get("model", "").lower()
+        assert call_count[0] == 2  # Both models tried
+
+    def test_gateway_both_fail(self):
+        """Test when both Gemini and Claude fail."""
+        from survey.captcha.gateway_solver import GatewaySolver
+
+        solver = GatewaySolver(api_key="test_gateway_key")
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="angular_drag_drop")
+
+        with patch.object(solver, "_call_gateway_api", return_value=None):
+            result = solver.solve(cdp, detection)
+
+        assert result.solved is False
+        assert result.reason == "both_models_failed"
+
+    def test_gateway_no_api_key_graceful_skip(self):
+        """Test graceful skip when AI_GATEWAY_API_KEY is not set."""
+        from survey.captcha.gateway_solver import GatewaySolver
+
+        # Create solver without API key
+        with patch.dict(os.environ, {"AI_GATEWAY_API_KEY": ""}, clear=True):
+            solver = GatewaySolver(api_key=None)
+
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="angular_drag_drop")
+
+        result = solver.solve(cdp, detection)
+
+        assert result.solved is False
+        assert result.reason == "api_key_not_set"
+
+    def test_gateway_coords_extraction(self):
+        """Test coordinate extraction from model response."""
+        from survey.captcha.gateway_solver import GatewaySolver
+
+        solver = GatewaySolver(api_key="test_key")
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="slider")
+
+        response = json.dumps({
+            "action_type": "slide",
+            "solved": True,
+            "data": {"distance": 150}
+        })
+
+        # Mock slider handle detection
+        cdp._eval_results = {
+            "slider": {"x": 50, "y": 300}
+        }
+
+        with patch.object(solver, "_call_gateway_api", return_value=response):
+            result = solver.solve(cdp, detection)
+
+        # Should attempt to execute slide action
+        assert result.captcha_type == "slider"
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# AUDIO SOLVER TESTS (3)
+# ══════════════════════════════════════════════════════════════════════════
+
+class TestAudioSolver:
+    """Tests für audio_solver.py."""
+
+    def test_audio_recaptcha_success(self):
+        """Test successful reCAPTCHA audio solve."""
+        from survey.captcha.audio_solver import AudioSolver
+
+        solver = AudioSolver(api_key="test_nvidia_key")
+        cdp = MockCDPConnection(eval_results={
+            "audio-button": True,
+            "audio-source": "https://example.com/audio.mp3",
+            "audio-response": True,
+            "verify": True,
+        })
+        detection = MockCaptchaDetection(captcha_type="recaptcha")
+
+        # Mock audio download and transcription
+        with patch("survey.captcha.audio_solver._click_audio_button", return_value=True), \
+             patch("survey.captcha.audio_solver._extract_audio_url", return_value="https://example.com/audio.mp3"), \
+             patch("survey.captcha.audio_solver._download_audio_b64", return_value="base64audio"), \
+             patch.object(solver, "_transcribe_audio", return_value="hello world"):
+            result = solver.solve(cdp, detection)
+
+        assert result.solved is True
+        assert result.extra.get("transcript") == "hello world"
+
+    def test_audio_hcaptcha_success(self):
+        """Test successful hCaptcha audio solve."""
+        from survey.captcha.audio_solver import AudioSolver
+
+        solver = AudioSolver(api_key="test_nvidia_key")
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="hcaptcha")
+
+        with patch("survey.captcha.audio_solver._click_audio_button", return_value=True), \
+             patch("survey.captcha.audio_solver._extract_audio_url", return_value="https://example.com/hcaptcha.mp3"), \
+             patch("survey.captcha.audio_solver._download_audio_b64", return_value="base64audio"), \
+             patch.object(solver, "_transcribe_audio", return_value="nine four two"):
+            result = solver.solve(cdp, detection)
+
+        assert result.solved is True
+        assert "nine four two" in result.extra.get("transcript", "")
+
+    def test_audio_parakeet_error(self):
+        """Test handling of Parakeet ASR errors."""
+        from survey.captcha.audio_solver import AudioSolver
+
+        solver = AudioSolver(api_key="test_nvidia_key")
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="recaptcha")
+
+        with patch("survey.captcha.audio_solver._click_audio_button", return_value=True), \
+             patch("survey.captcha.audio_solver._extract_audio_url", return_value="https://example.com/audio.mp3"), \
+             patch("survey.captcha.audio_solver._download_audio_b64", return_value="base64audio"), \
+             patch.object(solver, "_transcribe_audio", return_value=None), \
+             patch.object(solver, "_transcribe_via_openai_compat", return_value=None):
+            result = solver.solve(cdp, detection)
+
+        assert result.solved is False
+        assert result.reason == "transcription_failed"
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# FALLBACK CHAIN TESTS (4)
+# ══════════════════════════════════════════════════════════════════════════
+
+class TestFallbackChain:
+    """Tests für fallback_chain.py."""
+
+    def test_chain_success_step_1(self):
+        """Test chain succeeds on first step (NIM Primary)."""
+        from survey.captcha.fallback_chain import FallbackChain, CaptchaResult
+
+        chain = FallbackChain()
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="angular_drag_drop")
+
+        # Mock first solver succeeds
+        mock_result = CaptchaResult(solved=True, captcha_type="angular_drag_drop")
+
+        with patch.object(chain, "_solvers", [("nim_primary", lambda c, d: mock_result)]):
+            result = chain.solve_with_fallback(cdp, detection, "https://example.com")
+
+        assert result.solved is True
+        step_trace = result.extra.get("step_trace", [])
+        assert len(step_trace) == 1
+        assert step_trace[0]["solver"] == "nim_primary"
+        assert step_trace[0]["outcome"] == "success"
+
+    def test_chain_step1_fail_step2_succeeds(self):
+        """Test chain falls back to step 2 when step 1 fails."""
+        from survey.captcha.fallback_chain import FallbackChain, CaptchaResult
+
+        chain = FallbackChain()
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="angular_drag_drop")
+
+        failed_result = CaptchaResult(solved=False, reason="primary_failed")
+        success_result = CaptchaResult(solved=True, captcha_type="angular_drag_drop")
+
+        def mock_primary(c, d):
+            return failed_result
+
+        def mock_secondary(c, d):
+            return success_result
+
+        with patch.object(chain, "_solvers", [
+            ("nim_primary", mock_primary),
+            ("nim_secondary", mock_secondary),
+        ]):
+            result = chain.solve_with_fallback(cdp, detection, "https://example.com")
+
+        assert result.solved is True
+        step_trace = result.extra.get("step_trace", [])
+        assert len(step_trace) == 2
+        assert step_trace[0]["outcome"] == "failed"
+        assert step_trace[1]["outcome"] == "success"
+
+    def test_chain_all_vision_fail_audio_succeeds(self):
+        """Test chain falls back to audio when all vision solvers fail."""
+        from survey.captcha.fallback_chain import FallbackChain, CaptchaResult
+
+        chain = FallbackChain()
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="recaptcha")
+
+        failed_result = CaptchaResult(solved=False, reason="vision_failed")
+        audio_result = CaptchaResult(solved=True, captcha_type="recaptcha", token="test_token")
+
+        with patch.object(chain, "_solvers", [
+            ("nim_primary", lambda c, d: failed_result),
+            ("nim_secondary", lambda c, d: failed_result),
+            ("gateway", lambda c, d: failed_result),
+            ("audio", lambda c, d: audio_result),
+        ]):
+            result = chain.solve_with_fallback(cdp, detection, "https://example.com")
+
+        assert result.solved is True
+        step_trace = result.extra.get("step_trace", [])
+        assert step_trace[-1]["solver"] == "audio"
+        assert step_trace[-1]["outcome"] == "success"
+
+    def test_chain_all_fail_handoff(self):
+        """Test chain logs human handoff when all solvers fail."""
+        from survey.captcha.fallback_chain import FallbackChain, CaptchaUnsolvedError, CaptchaResult
+
+        chain = FallbackChain()
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="angular_drag_drop")
+
+        failed_result = CaptchaResult(solved=False, reason="all_failed")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(chain, "_solvers", [
+                ("nim_primary", lambda c, d: failed_result),
+                ("nim_secondary", lambda c, d: failed_result),
+                ("gateway", lambda c, d: failed_result),
+                ("audio", None),  # Audio not applicable for drag_drop
+            ]), \
+                 patch("survey.captcha.fallback_chain._ensure_logs_dir", return_value=Path(tmpdir)):
+
+                with pytest.raises(CaptchaUnsolvedError) as exc_info:
+                    chain.solve_with_fallback(cdp, detection, "https://example.com")
+
+                error = exc_info.value
+                assert error.captcha_type == "angular_drag_drop"
+                assert len(error.step_trace) >= 4  # 3 failed + skipped audio + handoff
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# LOGGING TESTS (3)
+# ══════════════════════════════════════════════════════════════════════════
+
+class TestLogging:
+    """Tests für Logging-Funktionalität."""
+
+    def test_jsonl_shape(self):
+        """Test JSONL log entry has correct structure."""
+        from survey.captcha.fallback_chain import _log_human_handoff
+
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(
+            captcha_type="angular_drag_drop",
+            frame_id="frame123",
+            dom_hint="target=28"
+        )
+        step_trace = [
+            {"solver": "nim_primary", "outcome": "failed", "error": "timeout"},
+            {"solver": "nim_secondary", "outcome": "failed", "error": "parse_error"},
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("survey.captcha.fallback_chain._ensure_logs_dir", return_value=Path(tmpdir)):
+                log_path = _log_human_handoff(cdp, detection, "https://test.com", step_trace)
+
+            # Read and parse JSONL
+            with open(log_path) as f:
+                entry = json.loads(f.readline())
+
+            # Verify structure
+            assert "timestamp" in entry
+            assert entry["detected_type"] == "angular_drag_drop"
+            assert entry["page_url"] == "https://test.com"
+            assert entry["frame_id"] == "frame123"
+            assert entry["dom_hint"] == "target=28"
+            assert "step_trace" in entry
+            assert "screenshot_b64" in entry
+
+    def test_step_trace_correctness(self):
+        """Test step_trace contains correct solver sequence."""
+        from survey.captcha.fallback_chain import _log_human_handoff
+
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="recaptcha")
+        step_trace = [
+            {"solver": "nim_primary", "outcome": "failed", "error": "error1", "elapsed_ms": 100},
+            {"solver": "nim_secondary", "outcome": "failed", "error": "error2", "elapsed_ms": 200},
+            {"solver": "gateway", "outcome": "skipped", "error": "no_api_key", "elapsed_ms": 0},
+            {"solver": "audio", "outcome": "failed", "error": "error3", "elapsed_ms": 300},
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("survey.captcha.fallback_chain._ensure_logs_dir", return_value=Path(tmpdir)):
+                log_path = _log_human_handoff(cdp, detection, "https://test.com", step_trace)
+
+            with open(log_path) as f:
+                entry = json.loads(f.readline())
+
+            logged_trace = entry["step_trace"]
+            assert len(logged_trace) == 4
+            assert logged_trace[0]["solver"] == "nim_primary"
+            assert logged_trace[1]["solver"] == "nim_secondary"
+            assert logged_trace[2]["outcome"] == "skipped"
+            assert logged_trace[3]["solver"] == "audio"
+
+    def test_screenshot_encoding(self):
+        """Test screenshot is properly base64 encoded."""
+        from survey.captcha.fallback_chain import _log_human_handoff
+
+        # Create mock with known screenshot data
+        test_png = b"\x89PNG\r\n\x1a\n" + b"fake_image_data"
+        test_b64 = base64.b64encode(test_png).decode()
+        cdp = MockCDPConnection(screenshot_b64=test_b64)
+
+        detection = MockCaptchaDetection(captcha_type="visual_text")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("survey.captcha.fallback_chain._ensure_logs_dir", return_value=Path(tmpdir)):
+                log_path = _log_human_handoff(cdp, detection, "https://test.com", [])
+
+            with open(log_path) as f:
+                entry = json.loads(f.readline())
+
+            # Verify base64 can be decoded
+            screenshot_b64 = entry["screenshot_b64"]
+            assert screenshot_b64 == test_b64
+            decoded = base64.b64decode(screenshot_b64)
+            assert decoded == test_png
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# INTEGRATION TEST
+# ══════════════════════════════════════════════════════════════════════════
+
+class TestIntegration:
+    """Integration tests für die gesamte Chain."""
+
+    def test_captcha_router_integration(self):
+        """Test that captcha_router.solve() delegates to fallback_chain."""
+        # This test verifies the surgical patch to captcha_router.py
+        # Note: Requires the actual captcha_router to be patched
+
+        from survey.captcha.fallback_chain import solve_with_fallback, CaptchaResult
+
+        cdp = MockCDPConnection()
+        detection = MockCaptchaDetection(captcha_type="angular_drag_drop")
+
+        # Mock all solvers to return success on first try
+        mock_result = CaptchaResult(solved=True, captcha_type="angular_drag_drop")
+
+        with patch("survey.captcha.fallback_chain._get_nim_primary_solver", return_value=lambda c, d: mock_result):
+            result = solve_with_fallback(cdp, detection, "https://test.com")
+
+        assert result.solved is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## SR-138: Captcha Fallback Chain — Multi-NIM + Vercel AI Gateway

### Chain (5 Stufen, alle kostenlos)
```
[1] NIM Primary (Nemotron-3-Nano-Omni) — existierend
    ↓ fail
[2] NIM Secondary (Qwen2.5-VL-72B auf NIM)
    ↓ fail
[3] Vercel AI Gateway (Gemini 3.1 Flash → Claude Opus 4.7)
    ↓ fail / AI_GATEWAY_API_KEY unset
[4] Audio Solver (NVIDIA Parakeet ASR)
    ↓ fail
[5] Human Handoff (logs/captcha-failures-*.jsonl)
```

### Neue Dateien
| Datei | Beschreibung |
|-------|-------------|
| `nim_secondary_solver.py` | Qwen2.5-VL-72B für Drag-Drop, Slider, Visual-Text |
| `gateway_solver.py` | Gemini (native bounding-box) + Claude (reasoning) |
| `audio_solver.py` | Parakeet ASR für reCAPTCHA/hCaptcha Audio |
| `fallback_chain.py` | Orchestrator, Step-Trace, JSONL-Logging |
| `test_captcha_fallback.py` | 18 Unit Tests mit Mocked HTTP |

### Acceptance Criteria
- [x] Keine bezahlten Services (2Captcha etc.)
- [x] AI SDK Pattern: Model-Strings wie `google/gemini-3.1-flash-image-preview`
- [x] Graceful skip wenn `AI_GATEWAY_API_KEY` nicht gesetzt
- [x] Circuit-Breaker und Retry analog zu `nim.py`
- [x] `CaptchaUnsolvedError` Exception exportiert
- [x] Human Handoff loggt nach `logs/captcha-failures-*.jsonl`
- [x] 18+ Tests (3 NIM, 5 Gateway, 3 Audio, 4 Chain, 3 Logging)

Closes #138