### PR TITLE
test(probe): SR-159 — path-guard failure demonstration (do not merge)

### DIFF
--- a/.github/workflows/path-guard.yml
+++ b/.github/workflows/path-guard.yml
@@ -1,0 +1,99 @@
+# PATH-GUARD WORKFLOW — SR-159
+#
+# Enforces the repo's path doctrine on every PR. The doctrine itself lives
+# in two places that MUST stay in sync:
+#
+#   1. survey-cli/AGENTS.md  § PATH DOCTRINE (human-readable spec)
+#   2. scripts/path_guard.py (machine-readable manifest + checker)
+#
+# This workflow is a thin shim around `scripts/path_guard.py --diff`.
+# Keep it small. All policy logic belongs in the Python script so the
+# pre-commit hook and CI run the exact same code path.
+#
+# History:
+# - 2026-05-13 SR-159: created. Reason: SR-154 (100-file PR landed in a
+#   non-existent dir) + SR-162 (daemon.py vs daemon/ shadow killed CI for
+#   a week). Both could have been blocked by a 5-line CI check.
+#
+# Style notes (mirroring .github/workflows/ci.yml §13.8.4):
+# - Action versions are Brain-property. Bumped explicitly, never @latest.
+# - actions/checkout@v5, setup-python@v6 to stay on Node-24 runtime.
+# - fetch-depth: 0 is REQUIRED because the guard runs `git diff
+#   $base...HEAD` and needs the merge-base reachable.
+
+name: path-guard
+
+on:
+  pull_request:
+    # No `branches:` filter — see ci.yml: PRs against integration branches
+    # must also be gated, otherwise drift sneaks in via long-running feat
+    # branches (SR-50..SR-55 precedent in PR #54).
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+  pull-requests: write   # for the failure comment
+
+jobs:
+  path-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Needed for `git diff $base...HEAD` to resolve the merge-base.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Run path-guard (diff mode)
+        id: guard
+        # The script uses $GITHUB_BASE_REF on pull_request events and falls
+        # back to origin/main on push events. No `pip install` — pure stdlib.
+        run: |
+          python scripts/path_guard.py --diff | tee path_guard.out
+        env:
+          # Explicit even though Actions sets it automatically — makes the
+          # script's behaviour obvious to anyone reading the workflow.
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+
+      - name: Comment on PR when guard fails
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const out = fs.existsSync('path_guard.out')
+              ? fs.readFileSync('path_guard.out', 'utf8')
+              : '(no output captured)';
+            const body = [
+              '### path-guard failed (SR-159)',
+              '',
+              'This PR adds files outside the canonical repo layout. The doctrine',
+              'lives in [`survey-cli/AGENTS.md` § PATH DOCTRINE](https://github.com/' +
+                context.repo.owner + '/' + context.repo.repo +
+                '/blob/main/survey-cli/AGENTS.md#path-doctrine-sr-159).',
+              '',
+              '<details><summary>Guard output</summary>',
+              '',
+              '```',
+              out,
+              '```',
+              '',
+              '</details>',
+              '',
+              'If the verdict is wrong (e.g. a genuinely new canonical area),',
+              '**STOP** and comment on the issue with rationale — do not work',
+              'around the guard.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/.github/workflows/path-guard.yml
+++ b/.github/workflows/path-guard.yml
@@ -55,7 +55,16 @@ jobs:
         id: guard
         # The script uses $GITHUB_BASE_REF on pull_request events and falls
         # back to origin/main on push events. No `pip install` — pure stdlib.
+        #
+        # `set -o pipefail` is REQUIRED — without it the exit code of `tee`
+        # (always 0) masks a non-zero exit from path_guard.py and the guard
+        # silently passes on real violations. This is not theoretical: the
+        # first iteration of this workflow shipped without pipefail, the
+        # demo probe PR (#174) showed the violations in the log but the
+        # check was marked green. Do NOT remove this line.
+        shell: bash
         run: |
+          set -o pipefail
           python scripts/path_guard.py --diff | tee path_guard.out
         env:
           # Explicit even though Actions sets it automatically — makes the

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,14 @@
-# Pre-Commit Configuration (SR-73, 2026-05-11)
-# Hooks enforce AGENTS.md Brain-Rules before commits
+# Pre-Commit Configuration
+#
+# Hooks enforce AGENTS.md Brain-Rules before commits. The CI workflows
+# in .github/workflows/ run the same checks in cloud — local hooks are
+# the fast-feedback mirror, not a substitute.
+#
+# History:
+# - SR-73 (2026-05-11): initial — submodule + black + pylint + standard hooks.
+# - SR-159 (2026-05-13): added `path-guard` local hook. Mirrors
+#   .github/workflows/path-guard.yml exactly. Doctrine lives in
+#   survey-cli/AGENTS.md § PATH DOCTRINE and scripts/path_guard.py.
 
 repos:
   # Submodule Validation (SR-73 §11.9)
@@ -8,6 +17,17 @@ repos:
       - id: check-submodules
         name: "Check Submodules Config (SR-73)"
         entry: python scripts/check_submodules.py
+        language: system
+        pass_filenames: false
+        stages: [commit]
+        always_run: true
+
+  # Path Doctrine (SR-159) — local mirror of .github/workflows/path-guard.yml
+  - repo: local
+    hooks:
+      - id: path-guard
+        name: "Path-Guard: repo layout doctrine (SR-159)"
+        entry: python scripts/path_guard.py --diff
         language: system
         pass_filenames: false
         stages: [commit]

--- a/agent-toolbox/foo.py
+++ b/agent-toolbox/foo.py
@@ -1,0 +1,1 @@
+# Intentional violation — banned dir (agent-toolbox)\n

--- a/core/network/bar.py
+++ b/core/network/bar.py
@@ -1,0 +1,1 @@
+# Intentional violation — banned dir (top-level core)\n

--- a/random_root.py
+++ b/random_root.py
@@ -1,0 +1,1 @@
+# Intentional violation — unknown root file\n

--- a/scripts/path_guard.py
+++ b/scripts/path_guard.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""SR-159 Path-Guard — enforce single-source-of-truth repo layout.
+
+================================================================================
+WHY THIS EXISTS  (read before you "fix" this file or argue with its verdict)
+================================================================================
+
+The stealth-runner repo has historically accumulated parallel Python source
+trees because successive agents disagreed on the canonical layout. The empirical
+record (do not lose this — it is the entire reason this guard exists):
+
+    ┌──────┬────────────────────────────────────────────────────────────────┐
+    │ SR # │ Drift event                                                    │
+    ├──────┼────────────────────────────────────────────────────────────────┤
+    │ 154  │ PR reformatted 100+ files into `agent-toolbox/core/network/`.  │
+    │      │ That tree did not exist in the canonical layout. PR had to be  │
+    │      │ discarded; cherry-picking onto `survey-cli/survey/network/`    │
+    │      │ was ~10× faster than resolving conflicts.                      │
+    │ 162  │ `survey-cli/survey/daemon.py` (file) coexisted with            │
+    │      │ `survey-cli/survey/daemon/`  (package). Python silently makes  │
+    │      │ the package win → `DaemonManager` becomes unreachable. CI was  │
+    │      │ red for 7+ consecutive runs before anybody traced it.          │
+    │ 159  │ This guard. Codifies the doctrine in a 5-line CI check so      │
+    │      │ neither failure mode can recur.                                │
+    └──────┴────────────────────────────────────────────────────────────────┘
+
+This script is the *executable form* of the path doctrine that lives in
+`survey-cli/AGENTS.md`. If the two ever disagree, AGENTS.md is intent and this
+file is enforcement — patch BOTH or you have created the next SR-154.
+
+================================================================================
+THE DOCTRINE  (the only Python source root is survey-cli/survey/)
+================================================================================
+
+Allowed top-level entries:
+    survey-cli/        ← ALL Python production code + tests + per-package docs
+    stealth-captcha/   ← captcha solver subsystem (in-scope for the project)
+    scripts/           ← bash + python utility scripts (CI helpers, audits)
+    .github/           ← workflows, issue templates, CODEOWNERS
+    docs/              ← markdown docs that are NOT AGENTS.md
+                        (kept as a *directory* — individual doc files are
+                         discouraged per project rule "docs go in code,
+                         AGENTS.md is the brain". The directory is allowed so
+                         legacy content can be deleted incrementally without
+                         needing a guard-exception each time.)
+    + root config files (pyproject.toml, README.md, CHANGELOG.md, ROADMAP.md,
+      Makefile, .gitignore, .pre-commit-config.yaml, .semgrep_rules.yaml,
+      .env.example, .gitnexus.yml, uv.lock, opencode.json, manifest.json,
+      graph.json, skills-lock.json, com.stealth-sync.daemon.plist)
+
+Banned top-level entries (any NEW file under these in a PR → guard fails):
+    agent-toolbox/   ← dead, Agent 11's tree, replaced by survey-cli/survey/
+    agent_toolbox/   ← typo-fork of above, dead on arrival
+    core/            ← top-level `core` was a failed attempt from #154
+    lib/             ← never canonical
+    src/             ← never canonical for this repo (survey-cli/ is the src)
+
+Banned drift patterns (anywhere in the tree):
+    <X>.py + <X>/    ← module-vs-package shadow. Python silently picks the
+                       package and makes the file unreachable. SR-162 saga.
+
+================================================================================
+HOW THE GUARD RUNS
+================================================================================
+
+Two modes:
+
+    --diff [<base-ref>]
+        CI mode. Compares working tree against <base-ref> (default:
+        origin/main, or $GITHUB_BASE_REF if set by GitHub Actions). Fails
+        only on files *introduced or modified* by this PR. Pre-existing
+        legacy paths are grandfathered — this is intentional, so SR-159
+        itself can land without first deleting agent-toolbox/.
+
+    --audit
+        Local / manual mode. Walks the entire tree and reports every
+        violation (banned dir, shadow pair, stray Python file) but exits 0.
+        Use this to plan cleanup PRs.
+
+    --strict
+        Same as --audit but exits non-zero on any violation. Will be
+        wired into CI *after* the cleanup PR removes legacy dirs.
+
+Exit codes: 0 = clean | 1 = violations found | 2 = invocation error.
+
+================================================================================
+DESIGN NOTES  (so the next agent does not "refactor" this away)
+================================================================================
+
+- Pure stdlib. No deps. Must run on a fresh runner before `pip install`.
+- No regex on commit messages, no parsing of issue numbers. Path manifest
+  is a Python dict literal in this file. Single source of truth.
+- The manifest is intentionally NOT moved into a YAML or markdown file —
+  doing so would (a) re-introduce the "docs vs reality" drift class this
+  guard exists to prevent and (b) violate the project rule that
+  documentation lives inside the code that uses it.
+- Pre-commit hook and CI workflow both shell out to this script with
+  identical args. Keep CLI flags stable across both.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from typing import Iterable
+
+# --- MANIFEST ---------------------------------------------------------------
+# Everything below this line is "the doctrine in machine-readable form".
+# Edit here, then mirror the human-readable version into
+# `survey-cli/AGENTS.md` under the PATH DOCTRINE section. Do not let the
+# two drift.
+
+#: Top-level directories that are allowed to contain *new* files.
+ALLOWED_TOP_DIRS: frozenset[str] = frozenset({
+    "survey-cli",
+    "stealth-captcha",
+    "scripts",
+    ".github",
+    "docs",
+})
+
+#: Top-level directories that must not receive any *new* files via PRs.
+#: Listed explicitly (rather than "everything not allowed") so that the
+#: failure message can cite the historical SR that killed the directory.
+BANNED_TOP_DIRS: dict[str, str] = {
+    "agent-toolbox": "dead since SR-154 — code moved to survey-cli/survey/",
+    "agent_toolbox": "typo-fork of agent-toolbox, never canonical",
+    "core":          "top-level 'core' was rejected in SR-154; use "
+                     "survey-cli/survey/<subpackage>/",
+    "lib":           "never canonical for this repo",
+    "src":           "never canonical for this repo; "
+                     "survey-cli/ is the source tree",
+}
+
+#: Top-level files that are allowed at repo root. Anything *new* added at
+#: root that is not in this allowlist (and is not a directory entry) trips
+#: the guard. Existing root files are grandfathered.
+ALLOWED_ROOT_FILES: frozenset[str] = frozenset({
+    "pyproject.toml", "README.md", "CHANGELOG.md", "ROADMAP.md", "Makefile",
+    ".gitignore", ".pre-commit-config.yaml", ".semgrep_rules.yaml",
+    ".env.example", ".gitnexus.yml", "uv.lock", "opencode.json",
+    "manifest.json", "graph.json", "skills-lock.json",
+    "com.stealth-sync.daemon.plist",
+})
+
+#: Hidden top-level dirs that are tool config (`.claude`, `.opencode`,
+#: `.qwen`, `.agents`). They are not policed by the guard — they only
+#: contain prompts/config, never importable code.
+IGNORED_TOP_PREFIXES: tuple[str, ...] = (".",)
+
+
+# --- HELPERS ----------------------------------------------------------------
+
+
+def _run(cmd: list[str]) -> str:
+    """Run a subprocess and return stdout. Empty string on failure."""
+    try:
+        return subprocess.check_output(cmd, text=True, stderr=subprocess.DEVNULL)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+
+
+def _changed_files(base_ref: str) -> list[str]:
+    """Return files changed vs base_ref. Excludes deletions (we only police
+    additions/modifications; deleting from a banned dir is *good*).
+    """
+    # `--diff-filter=d` excludes deletions. ACMRTUXB is everything else.
+    out = _run(["git", "diff", "--name-only", "--diff-filter=ACMRTUXB",
+                f"{base_ref}...HEAD"])
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def _all_tracked_files() -> list[str]:
+    out = _run(["git", "ls-files"])
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def _top_segment(path: str) -> str:
+    """First path segment. For root files, returns the filename itself."""
+    return path.split("/", 1)[0]
+
+
+# --- CHECKS -----------------------------------------------------------------
+
+
+def check_banned_top_dirs(files: Iterable[str]) -> list[str]:
+    """Flag any file whose top-level segment is in BANNED_TOP_DIRS."""
+    violations = []
+    for f in files:
+        top = _top_segment(f)
+        if top in BANNED_TOP_DIRS:
+            violations.append(
+                f"  BANNED DIR     {f}\n"
+                f"                 reason: {BANNED_TOP_DIRS[top]}"
+            )
+    return violations
+
+
+def check_unknown_top(files: Iterable[str]) -> list[str]:
+    """Flag any file whose top-level segment is neither allowed, banned,
+    a tool-config dot-dir, nor a recognised root file.
+    """
+    violations = []
+    for f in files:
+        top = _top_segment(f)
+        if top in ALLOWED_TOP_DIRS:
+            continue
+        if top in BANNED_TOP_DIRS:
+            continue  # already reported by check_banned_top_dirs
+        if top.startswith(IGNORED_TOP_PREFIXES):
+            continue
+        if "/" not in f:  # root file
+            if top in ALLOWED_ROOT_FILES:
+                continue
+            violations.append(
+                f"  UNKNOWN ROOT   {f}\n"
+                f"                 add it to ALLOWED_ROOT_FILES in "
+                f"scripts/path_guard.py if it is intentional"
+            )
+        else:
+            violations.append(
+                f"  UNKNOWN DIR    {f}\n"
+                f"                 top-level '{top}/' is not on the "
+                f"allowlist; if this is a new canonical area, propose it "
+                f"on the issue first (STOP-rule, see AGENTS.md)"
+            )
+    return violations
+
+
+def check_shadow_pairs(all_files: Iterable[str]) -> list[str]:
+    """Detect `<X>.py` and `<X>/` siblings in the same parent dir. Python
+    will pick the package and silently hide the module — see SR-162.
+    Operates on the *full* tracked set so we catch shadows that already
+    exist in main (those are the dangerous ones — they are live bugs).
+    """
+    files_by_parent: dict[str, set[str]] = {}
+    dirs_by_parent: dict[str, set[str]] = {}
+    for f in all_files:
+        parent = os.path.dirname(f)
+        name = os.path.basename(f)
+        files_by_parent.setdefault(parent, set()).add(name)
+        # every intermediate segment of f is a directory under its own parent
+        parts = f.split("/")
+        for i in range(1, len(parts)):
+            d_parent = "/".join(parts[: i - 1]) if i > 1 else ""
+            d_name = parts[i - 1]
+            dirs_by_parent.setdefault(d_parent, set()).add(d_name)
+
+    violations: list[str] = []
+    for parent, names in files_by_parent.items():
+        dirs_here = dirs_by_parent.get(parent, set())
+        for name in names:
+            if not name.endswith(".py"):
+                continue
+            stem = name[:-3]
+            if stem in dirs_here:
+                full_file = f"{parent}/{name}" if parent else name
+                full_dir = f"{parent}/{stem}/" if parent else f"{stem}/"
+                violations.append(
+                    f"  SHADOW PAIR    {full_file} vs {full_dir}\n"
+                    f"                 Python imports the package and hides "
+                    f"the module. Rename one (SR-162 precedent)."
+                )
+    return violations
+
+
+# --- MAIN -------------------------------------------------------------------
+
+
+def _resolve_base_ref(explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    # GitHub Actions sets this on pull_request events.
+    ref = os.environ.get("GITHUB_BASE_REF")
+    if ref:
+        return f"origin/{ref}"
+    return "origin/main"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="SR-159 Path-Guard: enforce repo layout doctrine.",
+    )
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--diff", nargs="?", const="", default=None,
+                      metavar="BASE_REF",
+                      help="check files changed vs BASE_REF "
+                           "(default: $GITHUB_BASE_REF or origin/main)")
+    mode.add_argument("--audit", action="store_true",
+                      help="walk entire tree, report violations, exit 0")
+    mode.add_argument("--strict", action="store_true",
+                      help="walk entire tree, exit non-zero on any violation")
+    args = p.parse_args(argv)
+
+    if args.diff is not None:
+        base_ref = _resolve_base_ref(args.diff or None)
+        files = _changed_files(base_ref)
+        mode_label = f"diff vs {base_ref}"
+    elif args.audit or args.strict:
+        files = _all_tracked_files()
+        mode_label = "full-tree audit"
+    else:
+        base_ref = _resolve_base_ref(None)
+        files = _changed_files(base_ref)
+        mode_label = f"diff vs {base_ref} (default)"
+
+    if not files:
+        print(f"path-guard: {mode_label}: no files to check — OK")
+        return 0
+
+    print(f"path-guard: {mode_label}: {len(files)} file(s) to check")
+
+    violations: list[str] = []
+    violations += check_banned_top_dirs(files)
+    violations += check_unknown_top(files)
+    # Shadow-pair check is global by design: a shadow already in main is
+    # a live bug, not something a single PR introduced.
+    violations += check_shadow_pairs(_all_tracked_files())
+
+    if not violations:
+        print("path-guard: OK — layout matches SR-159 doctrine.")
+        return 0
+
+    print("")
+    print("path-guard: VIOLATIONS")
+    print("─" * 72)
+    for v in violations:
+        print(v)
+    print("─" * 72)
+    print("")
+    print("Doctrine: survey-cli/AGENTS.md § PATH DOCTRINE (SR-159).")
+    print("If you believe this verdict is wrong, STOP and comment on the "
+          "issue rather than working around the guard.")
+
+    if args.audit and not args.strict:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/path_guard.py
+++ b/scripts/path_guard.py
@@ -70,7 +70,11 @@ Two modes:
         origin/main, or $GITHUB_BASE_REF if set by GitHub Actions). Fails
         only on files *introduced or modified* by this PR. Pre-existing
         legacy paths are grandfathered — this is intentional, so SR-159
-        itself can land without first deleting agent-toolbox/.
+        itself can land without first deleting agent-toolbox/. Shadow
+        pairs are likewise only blocking if the PR touches one half of
+        the pair; pre-existing shadows are reported as warnings (visible
+        on every PR but non-blocking until a dedicated cleanup PR fixes
+        them).
 
     --audit
         Local / manual mode. Walks the entire tree and reports every
@@ -228,11 +232,15 @@ def check_unknown_top(files: Iterable[str]) -> list[str]:
     return violations
 
 
-def check_shadow_pairs(all_files: Iterable[str]) -> list[str]:
-    """Detect `<X>.py` and `<X>/` siblings in the same parent dir. Python
-    will pick the package and silently hide the module — see SR-162.
-    Operates on the *full* tracked set so we catch shadows that already
-    exist in main (those are the dangerous ones — they are live bugs).
+def find_shadow_pairs(all_files: Iterable[str]) -> list[tuple[str, str]]:
+    """Return every `<X>.py` ↔ `<X>/` sibling pair in the tracked tree as
+    (file_path, dir_path) tuples. Python will pick the package and silently
+    hide the module — see SR-162.
+
+    This is split from the "format violations" step so the caller can decide
+    whether a given pair is *introduced by this PR* (→ blocking) or *already
+    existed in main* (→ informational warning that should not block a
+    governance PR — see SR-159 PR body).
     """
     files_by_parent: dict[str, set[str]] = {}
     dirs_by_parent: dict[str, set[str]] = {}
@@ -247,7 +255,7 @@ def check_shadow_pairs(all_files: Iterable[str]) -> list[str]:
             d_name = parts[i - 1]
             dirs_by_parent.setdefault(d_parent, set()).add(d_name)
 
-    violations: list[str] = []
+    pairs: list[tuple[str, str]] = []
     for parent, names in files_by_parent.items():
         dirs_here = dirs_by_parent.get(parent, set())
         for name in names:
@@ -257,12 +265,41 @@ def check_shadow_pairs(all_files: Iterable[str]) -> list[str]:
             if stem in dirs_here:
                 full_file = f"{parent}/{name}" if parent else name
                 full_dir = f"{parent}/{stem}/" if parent else f"{stem}/"
-                violations.append(
-                    f"  SHADOW PAIR    {full_file} vs {full_dir}\n"
-                    f"                 Python imports the package and hides "
-                    f"the module. Rename one (SR-162 precedent)."
-                )
-    return violations
+                pairs.append((full_file, full_dir))
+    return pairs
+
+
+def _format_shadow(file_path: str, dir_path: str) -> str:
+    return (
+        f"  SHADOW PAIR    {file_path} vs {dir_path}\n"
+        f"                 Python imports the package and hides the module. "
+        f"Rename one (SR-162 precedent)."
+    )
+
+
+def partition_shadow_pairs(
+    all_files: Iterable[str],
+    changed_files: Iterable[str],
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Split shadow pairs into (touched_by_diff, preexisting). A pair is
+    'touched_by_diff' if either half is in `changed_files`.
+
+    The 'touched' set blocks CI in --diff mode (the PR is actively making
+    the problem worse or introducing it fresh). The 'preexisting' set is
+    surfaced as a warning so it stays visible but does not block governance
+    work — see SR-159 PR body for rationale.
+    """
+    changed = set(changed_files)
+    touched: list[tuple[str, str]] = []
+    preexisting: list[tuple[str, str]] = []
+    for file_path, dir_path in find_shadow_pairs(all_files):
+        # A directory match means any changed file *under* that directory.
+        dir_prefix = dir_path  # already ends with '/'
+        if file_path in changed or any(c.startswith(dir_prefix) for c in changed):
+            touched.append((file_path, dir_path))
+        else:
+            preexisting.append((file_path, dir_path))
+    return touched, preexisting
 
 
 # --- MAIN -------------------------------------------------------------------
@@ -314,12 +351,41 @@ def main(argv: list[str] | None = None) -> int:
     violations: list[str] = []
     violations += check_banned_top_dirs(files)
     violations += check_unknown_top(files)
-    # Shadow-pair check is global by design: a shadow already in main is
-    # a live bug, not something a single PR introduced.
-    violations += check_shadow_pairs(_all_tracked_files())
+
+    # Shadow-pair handling depends on mode.
+    #
+    # --strict / --audit: report every shadow pair in the tree (`files`
+    # already equals the full tracked set in those modes).
+    # --diff: only *touched* shadow pairs are blocking — pre-existing pairs
+    # are surfaced as warnings so we do not punish governance/cleanup PRs
+    # for tech debt they did not create. See SR-159 PR body.
+    all_tracked = _all_tracked_files()
+    warnings: list[str] = []
+    if args.audit or args.strict:
+        for fp, dp in find_shadow_pairs(all_tracked):
+            violations.append(_format_shadow(fp, dp))
+    else:
+        touched, preexisting = partition_shadow_pairs(all_tracked, files)
+        for fp, dp in touched:
+            violations.append(_format_shadow(fp, dp))
+        for fp, dp in preexisting:
+            warnings.append(_format_shadow(fp, dp))
+
+    if warnings:
+        print("")
+        print("path-guard: pre-existing shadow pairs (warnings, not blocking):")
+        print("─" * 72)
+        for w in warnings:
+            print(w)
+        print("─" * 72)
+        print("Run `python scripts/path_guard.py --strict` locally to see "
+              "the full list. Resolve in a dedicated cleanup PR (SR-162-class).")
 
     if not violations:
-        print("path-guard: OK — layout matches SR-159 doctrine.")
+        if warnings:
+            print("path-guard: OK — no new violations from this PR.")
+        else:
+            print("path-guard: OK — layout matches SR-159 doctrine.")
         return 0
 
     print("")

--- a/survey-cli/AGENTS.md
+++ b/survey-cli/AGENTS.md
@@ -84,3 +84,178 @@ content: |
   ```
   
   Vorteil: 1 LLM-Call PRO SEITE (nicht pro Element!) = 10× effizienter
+  
+  ---
+  
+  ## PATH DOCTRINE (SR-159)
+  
+  **Status:** foundational, enforced by CI (`.github/workflows/path-guard.yml`)
+  and pre-commit (`scripts/path_guard.py`). Every agent reads this section
+  before writing the first line of code. The guard is the executable mirror
+  of this section — they MUST stay in sync.
+  
+  ### Authority Statement
+  
+  **`survey-cli/survey/` is the only Python source root. Anything else is
+  dead, legacy, or out-of-scope. New Python code that lands anywhere else
+  is a CI failure, not a stylistic preference.**
+  
+  ### Why this exists (empirical record — do not lose this)
+  
+  - **SR-154:** PR landed reformatting 100+ files into `agent-toolbox/core/network/`.
+    That tree did not exist in the canonical layout. PR was discarded;
+    cherry-picking onto `survey-cli/survey/network/` was ~10× faster than
+    resolving conflicts.
+  - **SR-162:** `survey-cli/survey/daemon.py` (file with `DaemonManager`)
+    coexisted with `survey-cli/survey/daemon/` (package with `SurveyDaemon`).
+    Python silently picked the package → `DaemonManager` became unreachable
+    → CI red for 7+ consecutive runs before anybody traced it. No reviewer
+    caught it — looked like two unrelated PRs at review time.
+  - **SR-159 (this section):** codifies both failure modes as a 5-line CI
+    check. From now on neither can recur without explicit override.
+  
+  ### Allowed top-level entries
+  
+  ```
+  stealth-runner/
+  ├── survey-cli/         ← ALL Python production code + tests
+  ├── stealth-captcha/    ← captcha solver subsystem (in-scope)
+  ├── scripts/            ← bash + python utility scripts (CI, audits)
+  ├── .github/            ← workflows, issue templates, CODEOWNERS
+  ├── docs/               ← legacy docs dir; new docs go in AGENTS.md
+  └── (root config files only — see scripts/path_guard.py ALLOWED_ROOT_FILES)
+  ```
+  
+  Tool-config dot-dirs (`.agents/`, `.claude/`, `.opencode/`, `.qwen/`) are
+  out-of-scope for the guard. They contain prompts/config only.
+  
+  ### Banned top-level entries
+  
+  | Dir              | Why dead                                                |
+  |------------------|---------------------------------------------------------|
+  | `agent-toolbox/` | dead since SR-154 — code moved to `survey-cli/survey/`  |
+  | `agent_toolbox/` | typo-fork of above, never canonical                     |
+  | `core/`          | top-level `core` rejected in SR-154                     |
+  | `lib/`           | never canonical                                         |
+  | `src/`           | never canonical; `survey-cli/` is the source tree       |
+  
+  Existing files under these dirs are **grandfathered** — the guard runs
+  in `--diff` mode, so legacy state is tolerated until a dedicated cleanup
+  PR removes it. Adding *new* files under any banned dir trips the guard.
+  
+  ### Banned drift patterns (anywhere in tree)
+  
+  - **Module-vs-package shadow:** `<X>.py` and `<X>/` siblings in the same
+    parent. Python silently picks the package; the module becomes
+    unreachable. SR-162 burned a week on exactly this. The guard checks
+    the full tree for this — there is currently one known shadow
+    (`survey-cli/survey.py` vs `survey-cli/survey/`) that must be resolved
+    in a follow-up PR.
+  
+  ### Recommended sub-packages under `survey-cli/survey/`
+  
+  ```
+  survey/
+  ├── daemon/           ← LangGraph + FastAPI orchestrator (single-daemon loop)
+  ├── reliability/      ← retry, DLQ, verifier (SR-167)
+  ├── network/          ← proxy, IP-quality (SR-151)
+  ├── captcha/          ← solver router + adapters (SR-138)
+  ├── observability/    ← events, traces, autodoc
+  ├── providers/        ← heypiggy, qualtrics, toluna, ...
+  └── (top-level modules: snapshot.py, accessibility.py, safe_executor.py, ...)
+  ```
+  
+  ### Pre-flight checklist (must pass before opening a PR)
+  
+  - [ ] Read this section in full
+  - [ ] Read the issue you are working on, in full
+  - [ ] Glob the top-level layout — confirm only allowed dirs are touched
+  - [ ] If your plan requires a NEW top-level dir → **STOP**, open a
+        clarification comment on the issue *before* writing code
+  - [ ] If you see code in `agent-toolbox/`, `agent_toolbox/`, top-level
+        `core/`, `lib/`, `src/` — it is dead. Do not modify unless you are
+        deleting it.
+  - [ ] If you create a module named `<X>.py`, confirm there is no
+        `<X>/` directory next to it (and vice versa)
+  - [ ] Run `python scripts/path_guard.py --diff` locally before pushing
+  
+  ### STOP rule (non-negotiable)
+  
+  If your plan deviates from the layout above — **STOP**. File a
+  clarification on the issue. Do not improvise. Working around the guard
+  (e.g. renaming a file just to make CI pass while smuggling the same
+  code into a banned location) is a fireable offence in this repo's
+  governance model.
+  
+  ### Deprecation-shim pattern (for retiring a module without breaking imports)
+  
+  When a module moves from old → new path, leave the old path as a shim
+  for one release cycle:
+  
+  ```python
+  # old/path/module.py
+  """DEPRECATED — moved to new.path.module (SR-NNN, will be removed in vX.Y)."""
+  import warnings
+  warnings.warn(
+      "old.path.module is deprecated; import from new.path.module",
+      DeprecationWarning,
+      stacklevel=2,
+  )
+  from new.path.module import *  # noqa: F401,F403
+  ```
+  
+  Then delete the shim in the next release. Never leave shims indefinitely
+  — they are SR-154 in slow motion.
+  
+  ### Python-version compatibility (hard requirement)
+  
+  - Targets: **3.12 + 3.13** (CI matrix in `.github/workflows/ci.yml`)
+  - `asyncio.run(...)` — never `asyncio.get_event_loop()`
+  - `datetime.now(timezone.utc)` — never `datetime.utcnow()`
+  - Zero deprecation warnings under either interpreter — CI fails on them
+  
+  ### Test discipline
+  
+  - Production tests live in `survey-cli/tests/`
+  - Fixtures live in `survey-cli/tests/fixtures/`
+  - **Never** put tests inside production modules
+  - **Never** put production code inside `survey-cli/tests/`
+  
+  ### Ruff / lint discipline
+  
+  - Line length: **100** (configured in `pyproject.toml`)
+  - `F401` (unused imports) is **hard** — no global ignore
+  - `# noqa` is allowed sparingly, but every occurrence must carry a
+    rationale comment on the same line
+  
+  ### Branch / commit / PR conventions
+  
+  - **Branch:** `feat/sr-NNN-short-description` or `fix/sr-NNN-...`
+  - **Commits:** conventional commits
+    (`feat(area): ...`, `fix(area): ...`, `chore(area): ...`)
+  - **PR title:** `feat(area): SR-NNN — title (#NNN)`
+  - **PR body:** must reference the issue, must include a before/after
+    summary of what an agent could not do before and can do now
+  
+  ### How the guard runs
+  
+  - **CI:** `.github/workflows/path-guard.yml` runs on every PR. Calls
+    `python scripts/path_guard.py --diff` with `$GITHUB_BASE_REF`.
+    Failure posts an annotated comment on the PR.
+  - **Local:** `.pre-commit-config.yaml` runs the same command on commit.
+    Use `pre-commit install` once per clone.
+  - **Audit:** `python scripts/path_guard.py --audit` walks the entire
+    tree and reports every violation without failing. Use this to plan
+    cleanup PRs.
+  - **Strict:** `python scripts/path_guard.py --strict` walks the entire
+    tree and fails on any violation. Will be wired into CI *after* the
+    cleanup PR removes the grandfathered legacy dirs.
+  
+  ### Out-of-scope (will be removed by follow-up PRs, not this one)
+  
+  This section ONLY introduces governance. The cleanup of existing
+  violations (deleting `agent-toolbox/`, `agent_toolbox/`, top-level
+  `core/`, `src/`, resolving the `survey.py` vs `survey/` shadow) lives
+  in separate, narrowly-scoped PRs that the guard itself makes safe to
+  land. Mixing governance and bulk-delete into one PR is exactly how
+  SR-154 happened.


### PR DESCRIPTION
**DO NOT MERGE — demonstration only.**

This is the failure-mode demo referenced by #173. The branch contains three intentional path-doctrine violations:

- `agent-toolbox/foo.py` — banned dir
- `core/network/bar.py` — banned dir
- `random_root.py` — unknown root file

Expected outcome: the `path-guard` check fails with cited reasons, demonstrating that the enforcement in #173 actually blocks drift.

Plus the global shadow-pair detector will surface the pre-existing `survey-cli/survey.py` vs `survey-cli/survey/` issue (an SR-162-class live bug to be resolved in a follow-up).

Close this PR after review without merging.
