### PR TITLE
ci(mypy): SR-190 — enforce type-checking (informational phase) (#189)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,31 @@ jobs:
       - name: Run ruff check
         run: ruff check survey-cli/survey --select E,W,F
 
+      # SR-190 (Issue #189) — mypy in CI, Phase 1: INFORMATIONAL ONLY.
+      # ----------------------------------------------------------------
+      # Doctrine (full rationale lives at the tail of survey-cli/AGENTS.md
+      # under "SR-190 - mypy in CI"). Short form here for the next agent:
+      # - Scope: survey-cli/survey/ (Production-Code). Tests OUT-OF-SCOPE.
+      # - Config: survey-cli/pyproject.toml has [tool.mypy] strict = true.
+      #   We respect that config; no CLI overrides here.
+      # - Matrix-Pin: ONLY runs on Python 3.13 (avoids double-counts in CI
+      #   logs and matches Issue #189's Python-3.13-as-baseline requirement).
+      # - Non-blocking: `|| true` forces exit 0. GitHub Actions runs each
+      #   `run:` block with `bash -e -o pipefail`, so `; true` would NOT
+      #   swallow mypy's non-zero exit — `set -e` aborts after `;`. You
+      #   MUST use `|| true` here.
+      # - --no-error-summary keeps raw `error:` lines grep-able from logs
+      #   (count via `grep -c "error:"`). Baseline at first run was 1075.
+      # - Promotion to Phase 2 (blocking): when count drops below 50, drop
+      #   the `|| true` and the `--no-error-summary`, then update the
+      #   AGENTS.md SR-190 block to "Phase 2 ACTIVE".
+      # - DO NOT add `--ignore-missing-imports` here. DO NOT inline
+      #   per-module overrides — those belong in pyproject.toml and need
+      #   a separate debt issue (precedent: SR-62/SR-63 for ruff/pytest).
+      - name: Type-check with mypy (SR-190 — informational phase)
+        if: matrix.python-version == '3.13'
+        run: cd survey-cli && mypy survey/ --no-error-summary 2>&1 || true
+
       - name: Run survey-cli tests
         env:
           PYTHONPATH: survey-cli

--- a/survey-cli/AGENTS.md
+++ b/survey-cli/AGENTS.md
@@ -265,3 +265,41 @@ content: |
   in separate, narrowly-scoped PRs that the guard itself makes safe to
   land. Mixing governance and bulk-delete into one PR is exactly how
   SR-154 happened.
+  
+  ---
+  
+  ##  SR-190 - mypy in CI (gradually enforcing types)
+  
+  **Status:** Phase 1 ACTIVE — informational only, non-blocking.
+  
+  **What happens:**
+  - CI workflow `.github/workflows/ci.yml` runs `mypy survey/` after
+    `ruff check` and before `pytest`, only on the Python 3.13 matrix leg.
+  - Scope: `survey-cli/survey/` (production code). Tests OUT-OF-SCOPE.
+  - Config: `survey-cli/pyproject.toml` -> `[tool.mypy] strict = true`.
+  - Exit code is forced to 0 via `|| true` (GHA shells run with
+    `bash -e -o pipefail`, so `; true` would NOT swallow the failure
+    — `set -e` aborts after `;`. MUST use `|| true`).
+  - `--no-error-summary` keeps raw `error:` lines grep-able in the log
+    (count via `grep -c "error:"`).
+  
+  **Why not blocking yet:**
+  - Baseline = 1075 errors (PR #193, run 25785123606).
+  - Hard gate would paint every PR red -> velocity killer.
+  - Phase 1 = visibility. Real bugs surfaced by mypy (60 attr-defined,
+    63 union-attr) get fixed as small surgical PRs under SR-194
+    (#198-#202, #210/#211/#213/#214/#217).
+  
+  **Promotion trigger to Phase 2 (blocking):**
+  - When error count < 50: drop the `|| true` and `--no-error-summary`,
+    then flip this block to "Phase 2 ACTIVE".
+  
+  **Audit trail:**
+  - 2026-05-13 (SR-190 / PR #193): step introduced. Baseline 1075 errors.
+    No local run, no clone — implemented entirely via GitHub API.
+  
+  **Forbidden:**
+  - NO `--ignore-missing-imports` CLI flag in the workflow.
+  - NO per-module `[[tool.mypy.overrides]]` without a separate debt
+    issue (precedent: SR-62/SR-63 for ruff/pytest).
+  - NO type-check on `survey-cli/tests/` in this phase.


### PR DESCRIPTION
## SR-190 — Enforce mypy in CI (Phase 1, informational)

Closes #189 (Phase 1 portion). Follows SR-187 (datetime.utcnow ban).

### Was

- Neuer Step in `.github/workflows/ci.yml`, nach `ruff check`, vor `pytest`:
  ```yaml
  - name: Type-check with mypy (SR-190 — informational phase)
    if: matrix.python-version == '3.13'
    run: cd survey-cli && mypy survey/ --no-error-summary 2>&1 || true
  ```
- Volle Doctrine als Inline-Kommentar direkt im Workflow.
- SR-190-Notiz an `survey-cli/AGENTS.md` angehängt.

### Acceptance Criteria (Issue #189)

- [x] `mypy`-Step in `.github/workflows/ci.yml`, **nach** ruff, **vor** pytest
- [x] Lauf auf Python 3.13 (`if: matrix.python-version == '3.13'`)
- [x] Baseline-Errorcount im PR-Body dokumentiert (siehe unten)
- [x] Non-blocking (`|| true`) → CI bleibt grün
- [x] Kurzer Kommentar in `AGENTS.md`: „mypy gradually enforcing types"

### Baseline (gemessen aus run 25785123606 / job 75736561320)

**1075 mypy-Errors** auf `survey-cli/survey/` mit `strict = true`.

**Top error categories:**
| count | category |
|------:|----------|
| 270 | `[no-untyped-def]` — fehlende Signatur-Annotationen |
| 220 | `[no-untyped-call]` — Aufrufe von ungetypten Funktionen |
| 209 | `[type-arg]` — `dict` / `list` ohne Generic-Args |
|  82 | `[no-any-return]` |
|  63 | `[union-attr]` — `Optional[X]` ohne None-Check |
|  60 | `[attr-defined]` — **echte Runtime-Bugs** (siehe Comment) |
|  44 | `[misc]` |
|  39 | `[assignment]` |

**Top offending modules:** `survey/graph/nodes.py` (85), `survey/runner.py` (61), `survey/chrome.py` (51), `survey/daemon_manager.py` (45), `survey/daemon/heypiggy.py` (44), `survey/daemon/browser_driver.py` (43), `survey/providers/purespectrum.py` (41), `survey/universal/loop.py` (36).

### Promotion-Trigger Phase 2

Phase-1-Contract verlangt < 50 errors → **Phase-2 nicht erreichbar ohne Cleanup-PRs**. Realistische Reihenfolge:

1. Banned-tree imports fixen (#159 / PR #173) → entfernt ~5 `import-not-found`
2. API-drift fixen (siehe Drift-Issue im nächsten Comment) → ~15 errors
3. `dict[str, Any]`/`list[str]` Annotations (mechanical) → ~209 errors
4. Param-typing für CLI-Funktionen (mechanical) → ~270 errors
5. Optional-None-Checks (`union-attr`) → ~63 errors (echte Reliability!)

Erst dann sinnvoll: gradueller `[[tool.mypy.overrides]]` für rest-Module mit `disallow_untyped_defs = false`, und schrittweise per-Modul auf `true` ziehen.

### Path-Doctrine

- Scope strikt: `survey-cli/survey/` (Production). Tests OUT-OF-SCOPE.
- Geändert: `.github/workflows/ci.yml`, `survey-cli/AGENTS.md`. Sonst nichts.
- mypy-Config bleibt in `survey-cli/pyproject.toml` (`strict = true` bereits gesetzt) — kein CLI-Override.

### Was DIESER PR NICHT macht

- Keine type-annotations Fixes (Phase 1 = nur visibility).
- Keine `--ignore-missing-imports`-Flags.
- Keine per-module `[[tool.mypy.overrides]]`.
- Kein scope-broadening auf `survey-cli/tests/`.

### Lessons während dieses PR

- Erster commit hatte `mypy ...; true`. GitHub Actions läuft Run-Blöcke mit `bash -e -o pipefail`, deshalb beendet `set -e` die Shell nach dem ersten Fail des `;`-Sequenz-Operators und `true` wird nie erreicht. **Korrekt ist `cmd || true`**. Inline-Kommentar im Workflow dokumentiert das jetzt für den nächsten Agent.