### PR TITLE
fix(reliability): SR-194 A1 — replace time.mgmtime typo with datetime.fromisoformat

### DIFF
--- a/survey-cli/survey/universal/loop.py
+++ b/survey-cli/survey/universal/loop.py
@@ -69,6 +69,7 @@ import re
 import time
 import urllib.request
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -86,7 +87,11 @@ def _acquire_lock(survey_id: str = "") -> bool:
             with open(LOCK_PATH, "r") as f:
                 lock = json.load(f)
             lock_time = lock.get("started", "2000-01-01")
-            age_min = (time.time() - time.mgmtime(time.mktime(time.strptime(lock_time[:19], "%Y-%m-%dT%H:%M:%S")))[0]) / 60  # noqa: E501
+            # SR-194 A1 + SR-187: parse ISO timestamp as tz-aware UTC.
+            # The previous implementation called a non-existent time module
+            # attribute and raised AttributeError on every lock recovery.
+            lock_dt = datetime.fromisoformat(lock_time[:19]).replace(tzinfo=timezone.utc)
+            age_min = (datetime.now(timezone.utc) - lock_dt).total_seconds() / 60
             if age_min < 30:
                 return False
         except Exception:
@@ -117,7 +122,11 @@ def _wipe_stale_locks():
             with open(LOCK_PATH, "r") as f:
                 lock = json.load(f)
             lock_time = lock.get("started", "2000-01-01")
-            age_min = (time.time() - time.mgmtime(time.mktime(time.strptime(lock_time[:19], "%Y-%m-%dT%H:%M:%S")))[0]) / 60  # noqa: E501
+            # SR-194 A1 + SR-187: parse ISO timestamp as tz-aware UTC.
+            # The previous implementation called a non-existent time module
+            # attribute and raised AttributeError on every stale-lock sweep.
+            lock_dt = datetime.fromisoformat(lock_time[:19]).replace(tzinfo=timezone.utc)
+            age_min = (datetime.now(timezone.utc) - lock_dt).total_seconds() / 60
             if age_min >= 30:
                 LOCK_PATH.unlink()
         except Exception:

--- a/survey-cli/tests/test_universal_loop.py
+++ b/survey-cli/tests/test_universal_loop.py
@@ -1,0 +1,91 @@
+"""Regression tests for survey.universal.loop lock helpers.
+
+SR-194 A1: `time.mgmtime` typo crashed every lock-recovery path with
+AttributeError. The fix replaces the broken time-module gymnastics with
+`datetime.fromisoformat(...).replace(tzinfo=timezone.utc)` (also satisfies
+SR-187 datetime hygiene: tz-aware UTC, no `datetime.utcnow`).
+
+These tests would have caught the bug if they had existed.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from survey.universal import loop as loop_module
+from survey.universal.loop import (
+    _acquire_lock,
+    _release_lock,
+    _wipe_stale_locks,
+)
+
+
+@pytest.fixture
+def tmp_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect LOCK_PATH into an isolated tmp dir for each test."""
+    lock_path = tmp_path / ".survey_lock.json"
+    monkeypatch.setattr(loop_module, "LOCK_PATH", lock_path)
+    return lock_path
+
+
+def _write_lock(path: Path, started: str, survey_id: str = "t") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"survey_id": survey_id, "started": started, "pid": 0}))
+
+
+def test_acquire_lock_no_existing_lock(tmp_lock: Path) -> None:
+    assert _acquire_lock("survey-1") is True
+    assert tmp_lock.exists()
+    data = json.loads(tmp_lock.read_text())
+    assert data["survey_id"] == "survey-1"
+
+
+def test_acquire_lock_blocks_when_fresh_lock_exists(tmp_lock: Path) -> None:
+    fresh_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    _write_lock(tmp_lock, fresh_iso)
+    assert _acquire_lock("survey-2") is False
+
+
+def test_acquire_lock_overrides_stale_lock(tmp_lock: Path) -> None:
+    """A lock older than 30 min must NOT block.
+
+    This is the regression test for SR-194 A1: previously this path
+    raised AttributeError before ever reaching the age comparison.
+    """
+    stale_iso = (
+        datetime.now(timezone.utc) - timedelta(hours=2)
+    ).strftime("%Y-%m-%dT%H:%M:%S")
+    _write_lock(tmp_lock, stale_iso)
+
+    # Pre-fix: AttributeError: module 'time' has no attribute 'mgmtime'
+    # Post-fix: returns True and replaces the stale lock file.
+    assert _acquire_lock("survey-3") is True
+    assert json.loads(tmp_lock.read_text())["survey_id"] == "survey-3"
+
+
+def test_wipe_stale_locks_removes_stale(tmp_lock: Path) -> None:
+    stale_iso = (
+        datetime.now(timezone.utc) - timedelta(hours=2)
+    ).strftime("%Y-%m-%dT%H:%M:%S")
+    _write_lock(tmp_lock, stale_iso)
+    _wipe_stale_locks()
+    assert not tmp_lock.exists()
+
+
+def test_wipe_stale_locks_keeps_fresh(tmp_lock: Path) -> None:
+    fresh_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    _write_lock(tmp_lock, fresh_iso)
+    _wipe_stale_locks()
+    assert tmp_lock.exists()
+
+
+def test_release_lock_idempotent(tmp_lock: Path) -> None:
+    """Releasing without a lock file must not raise."""
+    _release_lock()
+    _write_lock(tmp_lock, datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S"))
+    _release_lock()
+    assert not tmp_lock.exists()
+    _release_lock()  # second call also fine


### PR DESCRIPTION
## Summary

The lock-recovery paths in `survey/universal/loop.py` (originally lines 89 and 120) called `time.mgmtime` — a typo for `time.gmtime` — which raised `AttributeError` on every invocation. The recovery code therefore never actually ran: any leftover lock file from a previous run would either crash the new run or fall through silently to the bare `except: pass`.

This PR replaces the broken time-module gymnastics with a tz-aware UTC `datetime.fromisoformat` parse, satisfying both the SR-194 A1 fix and the SR-187 datetime-hygiene doctrine (no `datetime.utcnow`, everything is tz-aware).

## Changes

- `survey/universal/loop.py`
  - Add `from datetime import datetime, timezone` import.
  - `_acquire_lock` (formerly L89): parse `lock_time[:19]` via `datetime.fromisoformat`, attach UTC tz, compute age in minutes against `datetime.now(timezone.utc)`.
  - `_wipe_stale_locks` (formerly L120): same treatment.
- New file: `survey-cli/tests/test_universal_loop.py`
  - 6 regression cases covering `_acquire_lock` (no-lock / fresh-lock / stale-lock), `_wipe_stale_locks` (fresh vs. stale), and `_release_lock`.
  - The stale-lock cases would have caught the original AttributeError.

## Verification

- `grep -rn "mgmtime" survey-cli/survey/` → 0 hits.
- `grep -E '^\+.*datetime\.utcnow' <diff>` → 0 hits (SR-187 compliant).
- `pytest survey-cli/tests/test_universal_loop.py -v` → 6/6 green locally.
- `python3 scripts/path_guard.py --diff` → clean (only edits within allowed paths).
- `ruff check` on touched files → clean.

## Acceptance criteria (from #197)

- [x] `time.mgmtime` replaced — no residual references in source tree.
- [x] Two call sites both fixed using the same idiom.
- [x] `datetime.fromisoformat` with tz-aware UTC, no `datetime.utcnow`.
- [x] Regression test added that exercises lock-recovery without crashing.

Fixes #197 (A1)
Ref #194, #196 (Master Merge Plan), #187 (datetime hygiene)

— Agent-Kollege