### PR TITLE
fix(daemon): SR-194 A2-A5 — repair daemon CLI startup (run_forever + constructor drift)

### DIFF
--- a/survey-cli/survey/daemon/cli.py
+++ b/survey-cli/survey/daemon/cli.py
@@ -58,8 +58,10 @@ def get_persona():
     config = load_config()
     persona_config = config.get("persona", {})
 
+    # SR-194 A5: Persona (in survey.daemon.answer_engine) does not define
+    # a ``name`` field. The CLI previously passed ``name=...`` which raised
+    # TypeError on every persona instantiation.
     return Persona(
-        name=persona_config.get("name", "Alex"),
         age=persona_config.get("age", 32),
         gender=persona_config.get("gender", "non-binary"),
         occupation=persona_config.get("occupation", "Software Engineer"),
@@ -77,9 +79,10 @@ async def cmd_run_survey(args) -> int:
     load_config()
     persona = get_persona()
 
+    # SR-194 A4: SurveyAgentGraph.__init__ does not accept ``nvidia_local``;
+    # NVIDIA Vision is configured via the CAPTCHA stack, not the graph.
     graph = SurveyAgentGraph(
         persona=persona,
-        nvidia_local=True,  # FREE NVIDIA Vision for CAPTCHAs
         headless=not args.visible,
     )
 
@@ -160,12 +163,17 @@ def cmd_daemon_start(args) -> int:
     # Run in foreground
     print("Starting survey daemon in foreground (Ctrl+C to stop)...")
 
-    daemon = SurveyDaemon(
-        persona=persona,
-        nvidia_local=True,  # FREE NVIDIA Vision for CAPTCHAs
-    )
+    # SR-194 A3: SurveyDaemon.__init__ accepts only path kwargs
+    # (config_path / state_path / log_path). Persona is loaded from the
+    # config file inside the daemon, not injected here. The kwargs
+    # ``persona`` and ``nvidia_local`` were silent TypeErrors before.
+    _ = persona  # retained for parity with future Persona-injection refactor
+    daemon = SurveyDaemon()
 
     try:
+        # SR-194 A2: ``run_forever`` is now a public async alias on
+        # SurveyDaemon (see survey_daemon.py). The CLI previously called
+        # a non-existent method and crashed immediately.
         asyncio.run(daemon.run_forever())
     except KeyboardInterrupt:
         print("\nDaemon stopped")

--- a/survey-cli/survey/daemon/survey_daemon.py
+++ b/survey-cli/survey/daemon/survey_daemon.py
@@ -276,8 +276,20 @@ class SurveyDaemon:
             self._remove_pid()
             logger.info("Survey Daemon stopped.")
 
+    async def run_forever(self) -> None:
+        """
+        Async entry point for callers that already manage an event loop
+        (e.g. ``asyncio.run(daemon.run_forever())`` from the CLI).
+
+        This is the public counterpart to the private :meth:`_run` coroutine
+        and to the synchronous :meth:`start` wrapper. It runs until the
+        daemon's internal loop exits (SIGTERM/SIGINT, shutdown event,
+        or an unrecoverable error).
+        """
+        await self._run()
+
     def start(self) -> None:
-        """Start the daemon (blocking)."""
+        """Start the daemon (blocking, owns the event loop)."""
         asyncio.run(self._run())
 
     def stop(self) -> None:

--- a/survey-cli/tests/test_daemon_cli.py
+++ b/survey-cli/tests/test_daemon_cli.py
@@ -1,0 +1,115 @@
+"""SR-194 A2-A5: regression tests for survey.daemon.cli startup.
+
+These tests pin the four constructor/API drifts that were silently
+broken before this PR:
+
+- A2: ``SurveyDaemon.run_forever`` did not exist.
+- A3: ``SurveyDaemon(persona=..., nvidia_local=...)`` raised TypeError.
+- A4: ``SurveyAgentGraph(nvidia_local=...)`` raised TypeError.
+- A5: ``Persona(name=...)`` raised TypeError.
+
+The first test is the canonical AC probe from issue #199: a
+``python -m survey.daemon.cli --help`` subprocess must exit 0. The
+remaining tests use ``inspect.signature`` so they survive in
+environments where the heavy LangGraph runtime is not installed.
+"""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+import sys
+
+import pytest
+
+
+def test_cli_help_smoketest():
+    """`python -m survey.daemon.cli --help` exits 0 (AC from #199)."""
+    result = subprocess.run(
+        [sys.executable, "-m", "survey.daemon.cli", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"`survey.daemon.cli --help` exited {result.returncode}.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # Sanity: the help banner must mention the documented subcommands.
+    assert "daemon" in result.stdout
+    assert "run" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Signature pins. These do not import langgraph; they only import the
+# leaf modules whose constructors drifted. Each pin documents exactly
+# which kwarg used to crash in production.
+# ---------------------------------------------------------------------------
+
+
+def test_persona_has_no_name_kwarg():
+    """A5: Persona must not accept ``name=`` (the CLI used to pass it)."""
+    from survey.daemon.answer_engine import Persona
+
+    sig = inspect.signature(Persona)
+    assert "name" not in sig.parameters, (
+        "Persona accepts `name`; the SR-194 A5 fix in cli.py would be "
+        "redundant. Either remove this assertion or remove the kwarg "
+        "from get_persona() too."
+    )
+    # The fields the CLI actually uses must still be there.
+    for required in ("age", "gender", "occupation", "income_bracket",
+                     "education", "location", "interests"):
+        assert required in sig.parameters, f"Persona lost `{required}` field"
+
+
+def test_survey_daemon_has_run_forever_coroutine():
+    """A2: SurveyDaemon.run_forever exists and is a coroutine function."""
+    pytest.importorskip("langgraph")  # SurveyDaemon imports SurveyAgentGraph
+
+    from survey.daemon.survey_daemon import SurveyDaemon
+
+    assert hasattr(SurveyDaemon, "run_forever"), (
+        "SurveyDaemon.run_forever is missing again; cli.py calls "
+        "`asyncio.run(daemon.run_forever())`."
+    )
+    assert inspect.iscoroutinefunction(SurveyDaemon.run_forever), (
+        "SurveyDaemon.run_forever must be `async def` for the CLI to "
+        "wrap it in asyncio.run()."
+    )
+
+
+def test_survey_daemon_ctor_accepts_only_path_kwargs():
+    """A3: SurveyDaemon.__init__ must not silently accept `persona` etc."""
+    pytest.importorskip("langgraph")
+
+    from survey.daemon.survey_daemon import SurveyDaemon
+
+    sig = inspect.signature(SurveyDaemon)
+    accepted = set(sig.parameters)
+    assert "persona" not in accepted, (
+        "SurveyDaemon now accepts `persona`; revisit cli.py — the "
+        "A3 workaround can be reverted."
+    )
+    assert "nvidia_local" not in accepted, (
+        "SurveyDaemon now accepts `nvidia_local`; revisit cli.py — "
+        "the A3 workaround can be reverted."
+    )
+
+
+def test_survey_agent_graph_does_not_accept_nvidia_local():
+    """A4: SurveyAgentGraph.__init__ must not silently accept nvidia_local."""
+    pytest.importorskip("langgraph")
+
+    from survey.daemon.survey_agent_graph import SurveyAgentGraph
+
+    sig = inspect.signature(SurveyAgentGraph)
+    assert "nvidia_local" not in sig.parameters, (
+        "SurveyAgentGraph now accepts `nvidia_local`; revisit cli.py "
+        "— the A4 workaround can be reverted."
+    )
+    # The kwargs the CLI does pass must still be there.
+    for required in ("persona", "headless"):
+        assert required in sig.parameters, (
+            f"SurveyAgentGraph lost `{required}` kwarg"
+        )


### PR DESCRIPTION
## Summary

Four related bugs in `survey/daemon/cli.py`, all of which raised `TypeError` / `AttributeError` on the very first call (the daemon CLI was effectively unbootable):

| Bug | Symptom | Root cause |
|-----|---------|-----------|
| **A2** | `daemon.run_forever()` → AttributeError | `SurveyDaemon` exposes only `start` / `stop` / `is_running` / `get_status`. |
| **A3** | `SurveyDaemon(persona=…, nvidia_local=…)` → TypeError | `__init__` accepts only path kwargs; persona is loaded inside the daemon from the JSON config. |
| **A4** | `SurveyAgentGraph(nvidia_local=…)` → TypeError | `SurveyAgentGraph.__init__(persona, db_path, captcha_api_key, headless)`; NVIDIA Vision is configured via the CAPTCHA stack, not the graph. |
| **A5** | `Persona(name=…)` → TypeError | The `Persona` dataclass in `survey.daemon.answer_engine` defines no `name` field. |

## Resolution

Follows **Option B from #199** (CLI adapts to the real APIs — production-surface constructors stay stable), with **one** legitimate API addition on the daemon:

- **`survey_daemon.py`** — add `async def run_forever(self) -> None` as the public counterpart to the existing private `_run()` coroutine. This matches the CLI's intent `asyncio.run(daemon.run_forever())` and gives external callers that already own an event loop a stable entry point alongside the sync `start()` wrapper.
- **`cli.py`** — three small surgeries:
  - `get_persona()`: drop `name=…`.
  - `cmd_run_survey`: `SurveyAgentGraph` without `nvidia_local`.
  - `cmd_daemon_start`: `SurveyDaemon()` with no kwargs (persona still loaded from config inside the daemon).

The HeyPiggy call site at line 127 is intentionally left untouched — `run_heypiggy_session(…, nvidia_local=True, …)` is a legitimate signature.

## Verification

- `python3 -m py_compile` on both files → clean.
- `ruff check` on the touched files → clean.
- `python3 scripts/path_guard.py --diff` → clean (all edits within allowed paths).
- `pytest survey-cli/tests/test_daemon_cli.py -v` → 5/5 green locally.
  - `test_cli_help_smoketest`: the AC probe `python -m survey.daemon.cli --help` → exit 0 with the documented subcommands present in stdout.
  - 4× `inspect.signature` pins that will fail loudly if any of the four drifts ever returns.

## Acceptance criteria (from #199)

- [x] `python -m survey.daemon.cli --help` runs without crash.
- [x] `SurveyDaemon` no longer needs phantom kwargs; `run_forever` exists and is awaitable.
- [x] Smoketest in `survey-cli/tests/test_daemon_cli.py` exercises the `--help` subprocess.
- [x] No `attr-defined` errors against the previously-drifted constructors.

## Note on issue #198

`#198` was filed under the SR-194 A2-A5 cluster but its body describes the **A1 `time.mgmtime` bug**, i.e. it is a duplicate of `#197`. PR-A (`fix/sr-194-a1-time-gmtime`, #210) already closes `#197`. To avoid cross-stepping, this PR does **not** also reference `#198`; I will leave a duplicate-of comment on `#198` separately once `#210` lands.

Fixes #199 (A2, A3, A4, A5)
Ref #194, #196, #210

— Agent-Kollege