### PR TITLE
fix(cdp): SR-194 B1 — guard WebSocket | None call sites

### DIFF
--- a/survey-cli/survey/cdp_client.py
+++ b/survey-cli/survey/cdp_client.py
@@ -226,6 +226,14 @@ class CDPConnection:
         """
         if self._ws is None:
             self.connect()
+            # SR-194 B1: connect() either sets self._ws or raises
+            # CDPConnectionError (see line 179). If somehow neither
+            # happened, fail loudly instead of letting the next .send()
+            # crash with AttributeError deep in the retry loop.
+            if self._ws is None:
+                raise CDPConnectionError(
+                    f"connect() did not establish _ws for {self.ws_url}"
+                )
 
         msg_id = self._id_counter
         self._id_counter += 1
@@ -245,6 +253,17 @@ class CDPConnection:
 
         for attempt in range(max_attempts):
             try:
+                # SR-194 B1: re-narrow at the top of every attempt.
+                # close() in a previous iteration sets self._ws = None,
+                # and the matching self.connect() in the except branch
+                # below can silently fail (it sits inside `except`).
+                # Without this guard the next .send() would raise a
+                # confusing AttributeError instead of a CDPConnectionError.
+                if self._ws is None:
+                    raise CDPConnectionError(
+                        f"WebSocket is None entering attempt {attempt} "
+                        f"of CDP call {method!r}"
+                    )
                 self._ws.send(payload)
                 response = self._recv_until_id(msg_id)
                 response_data = json.loads(response)
@@ -303,6 +322,17 @@ class CDPConnection:
         async Event-Loop erweitern müssen.
         """
         while True:
+            # SR-194 B1: same invariant as in call() — the WebSocket can
+            # be torn down by a concurrent close() or by a failed
+            # reconnect. Without this guard recv() would raise
+            # AttributeError ("None has no attribute 'recv'") inside a
+            # while-True loop and the caller sees a stack with no clue
+            # about the underlying connection state.
+            if self._ws is None:
+                raise CDPConnectionError(
+                    "WebSocket disconnected during _recv_until_id "
+                    f"(target_id={target_id})"
+                )
             raw = self._ws.recv()
             try:
                 data = json.loads(raw)

--- a/survey-cli/survey/safe_executor.py
+++ b/survey-cli/survey/safe_executor.py
@@ -78,6 +78,17 @@ class SurveyFlowExecutor:
         if not self._ensure_connected():
             raise ConnectionError("WebSocket nicht verbunden. connect() zuerst aufrufen.")
 
+        # SR-194 B1: _ensure_connected() returning True guarantees that
+        # self._ws is a live WebSocket. The explicit narrow assertion
+        # both teaches mypy (the previous silent `union-attr` errors)
+        # and documents the invariant for the next reader. This is the
+        # hot-path call, so a strict assertion is preferred over a
+        # silent re-connect attempt (Option A in issue #201).
+        assert self._ws is not None, (
+            "_ensure_connected() returned True but self._ws is None — "
+            "broken invariant in SurveyFlowExecutor.connect()"
+        )
+
         msg_id = int(time.time() * 1000)
         payload = {"id": msg_id, "method": method}
         if params:

--- a/survey-cli/tests/test_websocket_none_handling.py
+++ b/survey-cli/tests/test_websocket_none_handling.py
@@ -1,0 +1,116 @@
+"""SR-194 B1: regression tests for WebSocket | None handling.
+
+Before this PR the four hot-path call sites below would raise
+``AttributeError: 'NoneType' object has no attribute 'send'`` (or
+``'recv'``) whenever the WebSocket was torn down between attempts:
+
+  - survey/safe_executor.py:86 (SurveyFlowExecutor._send_cdp .send)
+  - survey/safe_executor.py:87 (SurveyFlowExecutor._send_cdp .recv)
+  - survey/cdp_client.py:248   (CDPConnection.call .send)
+  - survey/cdp_client.py:306   (CDPConnection._recv_until_id .recv)
+
+These tests pin the new behaviour: the connection-state contract is
+enforced loudly (``CDPConnectionError`` / ``AssertionError``) instead
+of silently leaking ``AttributeError`` out of a ``while True`` loop.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from survey.cdp_client import CDPConnection, CDPConnectionError
+from survey.safe_executor import SurveyFlowExecutor
+
+
+# ---------------------------------------------------------------------------
+# safe_executor.py — Option A (strict assertion after _ensure_connected)
+# ---------------------------------------------------------------------------
+
+
+def test_safe_executor_asserts_ws_after_ensure_connected(monkeypatch):
+    """If _ensure_connected lies and returns True with _ws=None, fail fast."""
+    executor = SurveyFlowExecutor(tab_id="dummy")
+    # Force the broken invariant: _ensure_connected says True, _ws is None.
+    monkeypatch.setattr(executor, "_ensure_connected", lambda: True)
+    executor._ws = None
+
+    with pytest.raises(AssertionError, match="self._ws is None"):
+        executor._send_cdp("Page.navigate", {"url": "about:blank"})
+
+
+def test_safe_executor_raises_connection_error_when_not_connected(monkeypatch):
+    """_ensure_connected returning False must still surface ConnectionError."""
+    executor = SurveyFlowExecutor(tab_id="dummy")
+    monkeypatch.setattr(executor, "_ensure_connected", lambda: False)
+
+    with pytest.raises(ConnectionError):
+        executor._send_cdp("Page.navigate")
+
+
+# ---------------------------------------------------------------------------
+# cdp_client.py — Option B (loud CDPConnectionError instead of AttributeError)
+# ---------------------------------------------------------------------------
+
+
+def _make_conn(monkeypatch) -> CDPConnection:
+    """Build a CDPConnection without actually opening a WebSocket."""
+    conn = CDPConnection(ws_url="ws://test/devtools/page/X")
+    # Stub connect so the test never touches the network.
+    monkeypatch.setattr(conn, "connect", lambda: None)
+    return conn
+
+
+def test_cdp_client_call_raises_when_connect_does_not_set_ws(monkeypatch):
+    """call() should raise CDPConnectionError, never AttributeError.
+
+    Regression for cdp_client.py:248 — when connect() returns without
+    setting self._ws (e.g. a no-op stub in a test, or a partial
+    failure in production), the next iteration's ``.send()`` used to
+    crash with ``AttributeError``.
+    """
+    conn = _make_conn(monkeypatch)
+    assert conn._ws is None  # sanity
+
+    with pytest.raises(CDPConnectionError, match="did not establish _ws"):
+        conn.call("Page.navigate", retry=False)
+
+
+def test_cdp_client_recv_loop_raises_on_none_ws(monkeypatch):
+    """_recv_until_id must raise CDPConnectionError when _ws disappears.
+
+    Regression for cdp_client.py:306. Pre-fix this was a silent
+    ``AttributeError: 'NoneType' object has no attribute 'recv'``
+    inside a ``while True`` loop, with no hint of what went wrong.
+    """
+    conn = _make_conn(monkeypatch)
+    conn._ws = None
+
+    with pytest.raises(CDPConnectionError, match="disconnected during _recv_until_id"):
+        conn._recv_until_id(target_id=42)
+
+
+def test_cdp_client_call_re_narrows_each_attempt(monkeypatch):
+    """The per-attempt guard at the top of the retry loop must fire.
+
+    Set _ws to a stub that lets connect() pass the initial guard,
+    then drop it back to None to simulate a torn-down connection
+    entering the retry body.
+    """
+
+    class _Stub:
+        status = "open"
+
+        def send(self, payload):
+            raise OSError("simulated disconnect")
+
+    conn = _make_conn(monkeypatch)
+    conn._ws = _Stub()
+    # Reconnect callback also clears _ws to simulate a failed reconnect.
+    def _bad_reconnect():
+        conn._ws = None
+    monkeypatch.setattr(conn, "connect", _bad_reconnect)
+
+    with pytest.raises(CDPConnectionError):
+        # max_retries=2 by default; first attempt sends + raises OSError,
+        # connect() clears _ws, second attempt should hit the new guard.
+        conn.call("Page.navigate", retry=True)


### PR DESCRIPTION
## Summary

Four hot-path call sites accessed `self._ws.send` / `.recv` without narrowing `self._ws` from `WebSocket | None` first. mypy flagged all four as `union-attr` errors; at runtime they raised `AttributeError` deep inside retry loops, hiding the real cause (closed connection, failed reconnect).

| File | Line | Site | Fix |
|---|---|---|---|
| `survey/safe_executor.py` | ~81 | `_send_cdp` | `assert self._ws is not None` after `_ensure_connected()` returns True. |
| `survey/cdp_client.py` | ~229 | `call()` entry | Explicit `raise CDPConnectionError` if `connect()` returned but did not set `_ws`. |
| `survey/cdp_client.py` | ~256 | `call()` retry loop | Re-narrow at top of each attempt — `close()` sets `_ws = None` and the inner `connect()` in the except branch can silently fail. |
| `survey/cdp_client.py` | ~325 | `_recv_until_id` | Narrow inside the `while True` loop — a concurrent `close()` can yank `_ws` between iterations. |

All four now raise either `AssertionError` (`safe_executor` — broken invariant from `connect()`) or `CDPConnectionError` (`cdp_client` — recoverable connection state), never `AttributeError`.

## Why not just narrow once at the top of `call()`?

That was my first instinct and it's wrong. The retry loop in `call()` catches `ConnectionError` / `WebSocketException`, calls `self.close()` (which sets `_ws = None`), then `self.connect()` — but `connect()` is inside the `except` block, so if it raises, `last_error` is overwritten and the loop continues with `_ws = None`. A single narrow at the top of the function is not enough; the invariant must be re-established at every attempt. The same logic applies to `_recv_until_id`'s `while True` loop.

## Verification

- `pytest survey-cli/tests/test_websocket_none_handling.py -v` → 5/5 green locally.
  - `safe_executor` asserts after `_ensure_connected` returns True.
  - `safe_executor` raises `ConnectionError` when `_ensure_connected` returns False (no new code path needed).
  - `cdp_client.call` raises `CDPConnectionError` when `connect()` leaves `_ws=None`.
  - `cdp_client._recv_until_id` raises when `_ws` becomes None mid-loop.
  - `cdp_client.call` re-narrows at **each** retry attempt — not just once.
- mypy delta on touched files: 4 `union-attr` errors cleared.
- `python3 scripts/path_guard.py --diff` → clean.
- `ruff check` on touched files → clean.

## Acceptance criteria (from #201)

- [x] No `union-attr` errors against `_ws` in `safe_executor.py` or `cdp_client.py` for the four call sites.
- [x] AttributeError → typed error (`AssertionError` / `CDPConnectionError`).
- [x] Regression tests assert behaviour, not just types.

Fixes #201 (B1)
Ref #194, #196

— Agent-Kollege