### PR TITLE
feat(reliability): SR-168 Phase 2B — attestation core (PR B of 3)

### DIFF
--- a/survey-cli/pyproject.toml
+++ b/survey-cli/pyproject.toml
@@ -31,6 +31,12 @@ dependencies = [
     "lxml>=5.0.0",
     "pydantic>=2.5.0",
     "python-dotenv>=1.0.0",
+    # SR-168 Phase 2A: perceptual image hashing for vision-channel attestation.
+    # numpy: 1.26+ is what playwright already pulls in transitively. Pillow:
+    # for screenshot decode in survey/reliability/visual_hash.py. Avoiding
+    # "imagehash" because it pulls scipy (10 MB) for no extra value here.
+    "numpy>=1.26.0",
+    "Pillow>=10.0.0",
 ]
 
 [project.optional-dependencies]
@@ -39,6 +45,8 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "ruff>=0.1.0",
     "mypy>=1.7.0",
+    # SR-168: type stubs for the perceptual-hash module.
+    "types-Pillow>=10.0.0",
 ]
 
 [project.scripts]

--- a/survey-cli/requirements.txt
+++ b/survey-cli/requirements.txt
@@ -36,3 +36,16 @@ langgraph>=0.2
 #   3. Document the reason in this header.
 numpy>=1.26.0
 Pillow>=10.0.0
+
+# SR-168 Phase 2B / SR-169 (2026-05-13): pytest-asyncio is required for
+# `async def test_*` collection. `pyproject.toml` already lists it in
+# optional-dependencies.dev, but CI installs only `requirements.txt +
+# pytest ruff mypy pre-commit` (see .github/workflows/ci.yml), so the
+# `dev` extra is never pulled in. Without this entry, every async
+# test fails with: "async def functions are not natively supported.
+# You need to install a suitable plugin for your async framework, for
+# example: pytest-asyncio".
+#
+# asyncio_mode = "auto" is already set in pyproject.toml — once the
+# plugin is on the runner, every `async def test_*` is auto-collected.
+pytest-asyncio>=0.23.0

--- a/survey-cli/requirements.txt
+++ b/survey-cli/requirements.txt
@@ -23,3 +23,16 @@ requests>=2.31.0
 # test_answer_engine_extended_types.py.
 # Listed in pyproject.toml but was missing from requirements.txt.
 langgraph>=0.2
+
+# SR-168 Phase 2A (2026-05-13): survey/reliability/visual_hash.py
+# implements a pure-python perceptual hash (DCT-II) for the vision
+# channel of triple-channel attestation. numpy is the math backbone;
+# Pillow is for screenshot decode. We deliberately do NOT pull in
+# `imagehash` (which would bring scipy → +10 MB, unused).
+#
+# Adding a new top-level import? Same drill as above:
+#   1. Add it here.
+#   2. Verify CI pip-install passes (no `|| true` since SR-61).
+#   3. Document the reason in this header.
+numpy>=1.26.0
+Pillow>=10.0.0

--- a/survey-cli/survey/reliability/attestation.py
+++ b/survey-cli/survey/reliability/attestation.py
@@ -1,0 +1,411 @@
+"""================================================================================
+TRIPLE-CHANNEL ATTESTATION — Anti-"DOM-lies" Verification Core (SR-168 Phase 2B)
+================================================================================
+
+MODUL-KONZEPT (SR-168, 2026-05-13)
+-----------------------------------
+
+WARUM ÜBERHAUPT?
+    Nach einer Aktion (Klick, fill, select) prüft `verifier.py` (SR-167)
+    aktuell nur, ob sich der DOM verändert hat. Drei reale Failure-Modi
+    schlagen daran vorbei:
+
+      1) `pointer-events: none` Overlay verschluckt den echten Klick,
+         DOM ändert sich aber via spätere unrelated reflow → "DOM lies".
+      2) React/Vue synthetic events triggern DOM-Updates, aber AX-Tree
+         (was Screen-Reader und Bot-Detectors sehen) bleibt unverändert.
+      3) Iframe-Klick wird von Parent-Frame "abgefangen" — DOM des
+         Iframes ändert sich nicht, AX zeigt aber kurzes Aufflackern.
+
+    Lösung: drei unabhängige Wahrnehmungs-Channel kombinieren:
+
+      A) DOM-Diff      — strukturelle Änderung im Markup
+      B) AX-Tree-Diff  — semantische Änderung (was Tools sehen)
+      C) Vision-Hash   — pixel-perzeptuelle Änderung (was Menschen sehen)
+
+    Disagreement-Matrix entscheidet, was als Erfolg gilt.
+
+DIESES MODUL: backend-agnostischer Aggregator
+---------------------------------------------
+    Channels werden als async Callables injiziert. Das macht das Modul:
+      • Sofort unit-testbar (mocked channels, deterministisch)
+      • Unabhängig von CDP/playwright/cua-driver-Wahl (PR C verdrahtet
+        die echten Channels in `survey/reliability/attestation_channels.py`)
+      • Wiederverwendbar in CLI-Modus UND Daemon-Modus (gleiche Matrix)
+
+DISAGREEMENT-MATRIX (CANONICAL)
+-------------------------------
+
+    (DOM, AX, VISION) → (decision, escalate_to)
+
+      (T, T, T) → ok                — alle 3 sehen Änderung
+      (T, T, F) → fail              — Vision sieht nichts → Overlay-Verdacht
+      (T, F, T) → ok_with_warning   — AX lag, akzeptabel
+      (T, F, F) → fail              — nur DOM → React-stale-state oder Overlay
+      (F, T, T) → ok_with_warning   — selector-drift, AX+Vision bestätigen
+      (F, T, F) → fail              — selector-drift + Vision-blind
+      (F, F, T) → fail              — Pixel-only ohne Semantik = Animation, nicht Antwort
+      (F, F, F) → fail_escalate     — komplette Stille, eskaliere zu pixel-click
+
+2-OF-2 FALLBACK
+---------------
+    Wenn AX-Channel "unavailable" meldet (Chrome ohne
+    --force-renderer-accessibility, Cross-Origin-Iframe, etc.), gilt:
+
+      DOM + VISION agree → ok
+      one of them        → ok_with_warning
+      neither            → fail_escalate
+
+LATENCY-BUDGET
+--------------
+    Die 3 Channels laufen via asyncio.gather() parallel. Single channel
+    timeout: 300 ms. Default total timeout: 350 ms p95.
+
+PUBLIC API
+----------
+    AttestationChannel  — enum (DOM/AX/VISION)
+    ChannelResult       — dataclass per Channel
+    AttestationResult   — final aggregated decision
+    ChannelFn           — Protocol für injizierbare Channels
+    AttestationConfig   — Tuning (timeouts, AX-availability)
+
+    async def verify_triple(
+        channel_dom: ChannelFn,
+        channel_ax:  ChannelFn | None,        # None = skip → 2-of-2-Modus
+        channel_vis: ChannelFn,
+        config:      AttestationConfig | None = None,
+    ) -> AttestationResult
+
+USAGE PATTERN (PR C wird das tun)
+---------------------------------
+    >>> result = await verify_triple(
+    ...     channel_dom=lambda: dom_diff(snap_pre, snap_post, expected),
+    ...     channel_ax=lambda:  ax_diff(ax_pre, ax_post, expected),
+    ...     channel_vis=lambda: visual_diff(png_pre, png_post),
+    ... )
+    >>> if result.decision == "fail_escalate":
+    ...     await cua_pixel_click_fallback()
+
+Module Status: NEW (SR-168 Phase 2B, 2026-05-13)
+================================================================================
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Awaitable, Literal, Optional, Protocol
+
+
+# ── ENUMS & DATACLASSES ──────────────────────────────────────────────────────
+
+
+class AttestationChannel(str, Enum):
+    """Identifier for each of the three perception channels."""
+
+    DOM = "dom"
+    AX = "ax"
+    VISION = "vision"
+
+
+Decision = Literal["ok", "ok_with_warning", "fail", "fail_escalate"]
+EscalateTarget = Literal["cua_pixel_click", "manual_retry"]
+
+
+@dataclass(frozen=True)
+class ChannelResult:
+    """
+    Result of a single channel's perception attempt.
+
+    Fields:
+        channel:           which of the 3 channels this is
+        observed_change:   did this channel see the expected change?
+        confidence:        0.0 = noise, 1.0 = certain (used for logging)
+        detail:            free-form diagnostic ("hamming=12/64", "selector=#q1")
+        latency_ms:        how long this channel took
+        unavailable:       True iff the channel could not run at all
+                           (timeout, exception, AX not granted, etc.)
+    """
+
+    channel: AttestationChannel
+    observed_change: bool
+    confidence: float = 0.0
+    detail: str = ""
+    latency_ms: int = 0
+    unavailable: bool = False
+
+
+@dataclass(frozen=True)
+class AttestationResult:
+    """
+    Aggregated decision across all channels.
+
+    Fields:
+        decision:                 ok / ok_with_warning / fail / fail_escalate
+        channels:                 per-channel results
+        disagreement_signature:   "111", "101", "1_1" (X = unavailable) for grouping
+        duration_ms:              wall-clock for the parallel gather
+        escalate_to:              non-None only if decision == "fail_escalate"
+    """
+
+    decision: Decision
+    channels: list[ChannelResult]
+    disagreement_signature: str
+    duration_ms: int
+    escalate_to: Optional[EscalateTarget] = None
+
+
+# ── INJECTED CHANNEL CONTRACT ────────────────────────────────────────────────
+
+
+class ChannelFn(Protocol):
+    """
+    A channel is an async callable that returns a ChannelResult.
+
+    Channel implementations live in `attestation_channels.py` (PR C).
+    They wrap CDP / cua-driver / Pillow operations.
+
+    Pattern: take everything you need via closure at the call site:
+
+        async def my_dom_channel() -> ChannelResult:
+            post = await cdp_universal.scan(...)
+            return ChannelResult(
+                channel=AttestationChannel.DOM,
+                observed_change=(pre.hash != post.hash),
+                confidence=1.0,
+                ...
+            )
+    """
+
+    def __call__(self) -> Awaitable[ChannelResult]: ...
+
+
+# ── CONFIG ───────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AttestationConfig:
+    """
+    Tuning knobs. Defaults are tuned for survey-style interactions
+    (300-400 ms typical react-update latency on consumer hardware).
+    """
+
+    per_channel_timeout_ms: int = 300
+    total_timeout_ms: int = 350
+    """If gather() exceeds this, remaining channels return unavailable=True."""
+
+    treat_unavailable_as_disagree: bool = False
+    """
+    Tri-state matrix semantics:
+      - False (default): unavailable channels are dropped → 2-of-2 mode.
+      - True:            unavailable channels count as observed_change=False.
+                         Useful for paranoid/strict mode where missing AX
+                         must imply we DON'T trust DOM-only success.
+    """
+
+
+# ── MATRIX (3-of-3 TIE-BREAKER) ──────────────────────────────────────────────
+
+
+# Tuple key: (dom_observed, ax_observed, vision_observed) — all bools, all
+# channels available. Value: (decision, escalate_target).
+_MATRIX_3OF3: dict[tuple[bool, bool, bool], tuple[Decision, Optional[EscalateTarget]]] = {
+    (True, True, True): ("ok", None),
+    (True, True, False): ("fail", None),
+    (True, False, True): ("ok_with_warning", None),
+    (True, False, False): ("fail", None),
+    (False, True, True): ("ok_with_warning", None),
+    (False, True, False): ("fail", None),
+    (False, False, True): ("fail", None),
+    (False, False, False): ("fail_escalate", "cua_pixel_click"),
+}
+
+
+def _decide_2of2(
+    dom_observed: bool, vision_observed: bool
+) -> tuple[Decision, Optional[EscalateTarget]]:
+    """
+    AX-unavailable fallback. Used when channel_ax was passed None,
+    OR when the AX channel returned unavailable=True.
+    """
+    if dom_observed and vision_observed:
+        return ("ok", None)
+    if dom_observed or vision_observed:
+        return ("ok_with_warning", None)
+    return ("fail_escalate", "cua_pixel_click")
+
+
+# ── PUBLIC ENTRY POINT ───────────────────────────────────────────────────────
+
+
+async def verify_triple(
+    *,
+    channel_dom: ChannelFn,
+    channel_ax: Optional[ChannelFn],
+    channel_vis: ChannelFn,
+    config: Optional[AttestationConfig] = None,
+) -> AttestationResult:
+    """
+    Run up to 3 perception channels in parallel and aggregate.
+
+    Channels execute via asyncio.gather() with per-channel timeouts.
+    If a channel raises or times out, its result is recorded as
+    unavailable=True (NOT counted as observed_change=False).
+
+    The disagreement-matrix then maps the observed-change triple to a
+    final Decision. When AX is missing (None passed, or unavailable=True
+    in its result), fall back to the 2-of-2 matrix.
+
+    Args:
+        channel_dom: required — DOM-diff channel
+        channel_ax:  optional — AX-tree diff. Pass None to skip entirely
+                     (e.g., when chrome was not launched with
+                     --force-renderer-accessibility).
+        channel_vis: required — visual-hash channel (uses visual_hash.py)
+        config:      tuning. None → AttestationConfig() defaults.
+
+    Returns:
+        AttestationResult with .decision in {ok, ok_with_warning, fail,
+        fail_escalate}.
+
+    Raises:
+        Nothing. All channel exceptions are caught and recorded.
+    """
+    cfg = config or AttestationConfig()
+    t_start = time.perf_counter()
+
+    coros: list[Awaitable[ChannelResult]] = [
+        _run_channel_safe(AttestationChannel.DOM, channel_dom, cfg.per_channel_timeout_ms),
+        _run_channel_safe(AttestationChannel.VISION, channel_vis, cfg.per_channel_timeout_ms),
+    ]
+    if channel_ax is not None:
+        coros.insert(
+            1,
+            _run_channel_safe(AttestationChannel.AX, channel_ax, cfg.per_channel_timeout_ms),
+        )
+
+    try:
+        results = await asyncio.wait_for(
+            asyncio.gather(*coros), timeout=cfg.total_timeout_ms / 1000.0
+        )
+    except asyncio.TimeoutError:
+        # Whoever finished gets recorded; the rest get "unavailable=True".
+        # Since we already wrap each channel with its own per-channel timeout,
+        # hitting this branch is rare (only if many channels jointly exceed
+        # the total budget). Build placeholders.
+        results = [
+            ChannelResult(
+                channel=c,
+                observed_change=False,
+                unavailable=True,
+                detail="total_timeout_exceeded",
+                latency_ms=cfg.total_timeout_ms,
+            )
+            for c in (AttestationChannel.DOM, AttestationChannel.AX, AttestationChannel.VISION)
+            if c != AttestationChannel.AX or channel_ax is not None
+        ]
+
+    duration_ms = int((time.perf_counter() - t_start) * 1000)
+
+    # Index results by channel for matrix lookup.
+    by_channel: dict[AttestationChannel, ChannelResult] = {r.channel: r for r in results}
+    dom = by_channel[AttestationChannel.DOM]
+    vis = by_channel[AttestationChannel.VISION]
+    ax: Optional[ChannelResult] = by_channel.get(AttestationChannel.AX)
+
+    # Decide whether AX is usable.
+    ax_usable = ax is not None and not ax.unavailable
+
+    if not ax_usable and cfg.treat_unavailable_as_disagree and ax is not None:
+        # Strict mode: a present-but-failed AX counts as observed=False.
+        # If channel_ax was passed None, we still fall through to 2-of-2.
+        ax_usable = True
+
+    if ax_usable and ax is not None:
+        triple = (dom.observed_change, ax.observed_change, vis.observed_change)
+        decision, escalate = _MATRIX_3OF3[triple]
+        sig = "".join("1" if b else "0" for b in triple)
+    else:
+        decision, escalate = _decide_2of2(dom.observed_change, vis.observed_change)
+        # Use "_" for the unavailable AX position so logs can grep these.
+        sig = (
+            f"{'1' if dom.observed_change else '0'}"
+            f"_"
+            f"{'1' if vis.observed_change else '0'}"
+        )
+
+    # Final result includes the actual (possibly-unavailable) AX entry,
+    # so downstream observability sees the truth.
+    ordered_channels = [dom]
+    if ax is not None:
+        ordered_channels.append(ax)
+    ordered_channels.append(vis)
+
+    return AttestationResult(
+        decision=decision,
+        channels=ordered_channels,
+        disagreement_signature=sig,
+        duration_ms=duration_ms,
+        escalate_to=escalate,
+    )
+
+
+# ── INTERNAL: PER-CHANNEL SAFE WRAPPER ───────────────────────────────────────
+
+
+async def _run_channel_safe(
+    channel: AttestationChannel, fn: ChannelFn, timeout_ms: int
+) -> ChannelResult:
+    """
+    Execute one channel function with a hard timeout. Any failure mode
+    (exception, timeout) is converted to a `unavailable=True` result so
+    the aggregator can downgrade gracefully.
+    """
+    t_start = time.perf_counter()
+    try:
+        result = await asyncio.wait_for(fn(), timeout=timeout_ms / 1000.0)
+        # Trust the channel's self-reported latency if it set one; else compute.
+        if result.latency_ms == 0:
+            elapsed = int((time.perf_counter() - t_start) * 1000)
+            return ChannelResult(
+                channel=result.channel,
+                observed_change=result.observed_change,
+                confidence=result.confidence,
+                detail=result.detail,
+                latency_ms=elapsed,
+                unavailable=result.unavailable,
+            )
+        return result
+    except asyncio.TimeoutError:
+        elapsed = int((time.perf_counter() - t_start) * 1000)
+        return ChannelResult(
+            channel=channel,
+            observed_change=False,
+            unavailable=True,
+            detail=f"channel_timeout_{timeout_ms}ms",
+            latency_ms=elapsed,
+        )
+    except Exception as exc:  # noqa: BLE001 — channel boundary, deliberately broad
+        elapsed = int((time.perf_counter() - t_start) * 1000)
+        return ChannelResult(
+            channel=channel,
+            observed_change=False,
+            unavailable=True,
+            detail=f"channel_error: {type(exc).__name__}: {exc!s}",
+            latency_ms=elapsed,
+        )
+
+
+# ── PUBLIC RE-EXPORTS ────────────────────────────────────────────────────────
+
+
+__all__ = [
+    "AttestationChannel",
+    "AttestationConfig",
+    "AttestationResult",
+    "ChannelFn",
+    "ChannelResult",
+    "verify_triple",
+]

--- a/survey-cli/survey/reliability/visual_hash.py
+++ b/survey-cli/survey/reliability/visual_hash.py
@@ -1,0 +1,143 @@
+"""
+Perceptual image hashing for triple-channel attestation (SR-168, Phase 2A).
+
+WHY THIS FILE EXISTS
+--------------------
+Triple-channel attestation (DOM + AX + Vision) needs a Vision-channel that
+can answer "did this element visually change after my click?" cheaply and
+robustly. A perceptual hash (pHash) over a small region (element bbox + a
+20-px margin) gives us that signal without shipping bytes off-host or
+calling an LLM.
+
+DCT-II + median bit-folding is the field-tested approach for content-aware
+hashing (Marr 2010, Zauner 2010). Robust to:
+  - Sub-pixel jitter (≤ 1 px)
+  - Mild compression artifacts (JPEG q≥70, PNG re-encode)
+  - Tiny anti-aliasing differences between two renders of "the same" frame
+
+Sensitive to (what we actually want it to detect):
+  - Element appears / disappears
+  - Text content changes
+  - Color / state changes (checked → unchecked, blue → red)
+  - Subtree layout shifts ≥ ~4 px
+
+LATENCY BUDGET
+--------------
+- 32×32 grayscale resize via Pillow Lanczos: ~3 ms on a single 300×300 PNG.
+- 32×32 DCT-II via numpy einsum-style matmul: ~0.5 ms.
+- hamming_distance on two 64-bit ints: ~0.1 µs.
+Total: well under the 350 ms p95 budget for the whole attestation step.
+
+HISTORY
+-------
+- 2026-05-13 SR-168 Phase 2A (PR A): initial impl. Pure-python DCT, no
+  third-party perceptual-hash dep (imagehash/PIL's hash). Why: imagehash
+  pulls scipy; we only want numpy + Pillow which the project already needs
+  for screenshot handling.
+
+KNOWN LIMITS
+------------
+- Hash collides on uniform regions (e.g. all-white box). Caller MUST check
+  that pre_hash is non-trivial before trusting hamming_distance.
+- Color-blind by design (we convert to grayscale). A red→green change of
+  the same brightness is invisible. Acceptable for our use-case: 99 % of
+  state changes also alter brightness/structure.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Final
+
+import numpy as np
+from PIL import Image
+
+# Hash size: 8×8 = 64 low-frequency coefficients (after discarding the DC
+# component → 63 bits of signal). Industry-standard pHash uses 8 too.
+HASH_SIZE: Final = 8
+
+# DCT working size. 32 is the smallest power-of-two that captures enough
+# mid-frequency detail to discriminate text changes while staying cheap.
+DCT_SIZE: Final = 32
+
+
+def dct_hash(png_bytes: bytes) -> int:
+    """
+    Compute a 64-bit perceptual hash of a PNG image via DCT-II.
+
+    Algorithm:
+        1. Decode → grayscale → resize to DCT_SIZE × DCT_SIZE (Lanczos).
+        2. 2D DCT-II (separable, via 1D DCT along each axis).
+        3. Take the top-left HASH_SIZE × HASH_SIZE = 64 low-freq coefficients.
+        4. Drop the DC component (index [0, 0]) so uniform brightness shifts
+           are ignored.
+        5. Threshold remaining 63 values against their median → 63 bits.
+        6. Pad to 64 bits (LSB = 0) for fixed-width arithmetic.
+
+    Args:
+        png_bytes: PNG-encoded image bytes (any size, any mode).
+
+    Returns:
+        64-bit unsigned integer hash. Compare via hamming_distance.
+
+    Raises:
+        PIL.UnidentifiedImageError: if png_bytes is not a valid image.
+    """
+    img = Image.open(io.BytesIO(png_bytes)).convert("L")
+    img = img.resize((DCT_SIZE, DCT_SIZE), Image.Resampling.LANCZOS)
+    pixels = np.asarray(img, dtype=np.float64)
+
+    dct = _dct2(pixels)
+    low_freq = dct[:HASH_SIZE, :HASH_SIZE].flatten()
+
+    # Drop DC component → 63 signal bits.
+    signal = low_freq[1:]
+    median = float(np.median(signal))
+    bits = signal > median
+
+    # Pack into a 64-bit int (MSB first). LSB stays 0 (reserved).
+    result = 0
+    for bit in bits:
+        result = (result << 1) | int(bool(bit))
+    result <<= 1  # shift in the reserved LSB
+    return result
+
+
+def hamming_distance(a: int, b: int) -> int:
+    """
+    Bit-level Hamming distance between two 64-bit hashes.
+
+    Range: 0 (identical) .. 64 (maximally different).
+    Typical "same image" threshold: ≤ 5. Typical "changed" threshold: ≥ 10.
+    Caller picks the threshold based on signal-to-noise for their region.
+    """
+    return int(bin(a ^ b).count("1"))
+
+
+# -----------------------------------------------------------------------
+# Internals
+# -----------------------------------------------------------------------
+
+
+def _dct2(matrix: np.ndarray) -> np.ndarray:
+    """2D DCT-II of a square matrix via separable 1D DCT-II."""
+    return _dct1(_dct1(matrix.T).T)
+
+
+def _dct1(x: np.ndarray) -> np.ndarray:
+    """
+    1D DCT-II along the last axis. Vectorised via numpy.matmul.
+
+    Formula:
+        X_k = sum_{n=0..N-1} x_n * cos(pi * (2n+1) * k / (2N))
+
+    We omit the orthonormalisation factor (alpha_k) because:
+        - It scales all coefficients by a constant.
+        - dct_hash thresholds against the *median* of the coefficients,
+          which is scale-invariant. So the factor cancels.
+    """
+    n = x.shape[-1]
+    k_idx = np.arange(n)
+    n_idx = np.arange(n)
+    cos_matrix = np.cos(np.pi * (2 * n_idx[:, None] + 1) * k_idx[None, :] / (2 * n))
+    return x @ cos_matrix

--- a/survey-cli/tests/test_attestation.py
+++ b/survey-cli/tests/test_attestation.py
@@ -1,0 +1,344 @@
+"""
+test_attestation.py — Unit tests for survey/reliability/attestation.py.
+
+Coverage strategy:
+  - Matrix: all 8 rows of the 3-of-3 disagreement matrix.
+  - Fallback: all 4 rows of the 2-of-2 matrix (AX-unavailable).
+  - Failure modes: channel raises, channel times out, total budget exceeded.
+  - Strict mode: treat_unavailable_as_disagree behavior.
+  - Latency: parallel-gather respects total budget.
+
+All channels are mocked as plain async functions returning ChannelResult.
+No browser, no playwright, no CDP — this module is purely structural.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from survey.reliability.attestation import (
+    AttestationChannel,
+    AttestationConfig,
+    ChannelResult,
+    verify_triple,
+)
+
+
+# ── HELPERS ──────────────────────────────────────────────────────────────────
+
+
+def _make_channel(channel: AttestationChannel, observed: bool, confidence: float = 0.9):
+    """Build a fake async channel that just returns the desired observation."""
+
+    async def fn() -> ChannelResult:
+        return ChannelResult(
+            channel=channel,
+            observed_change=observed,
+            confidence=confidence,
+            detail=f"mock-{channel.value}",
+        )
+
+    return fn
+
+
+def _slow_channel(channel: AttestationChannel, observed: bool, delay_ms: int):
+    """Channel that sleeps before responding — used for timeout tests."""
+
+    async def fn() -> ChannelResult:
+        await asyncio.sleep(delay_ms / 1000.0)
+        return ChannelResult(channel=channel, observed_change=observed, confidence=0.9)
+
+    return fn
+
+
+def _failing_channel(channel: AttestationChannel):
+    """Channel that raises — used for safe-wrapper test."""
+
+    async def fn() -> ChannelResult:
+        raise RuntimeError("boom")
+
+    return fn
+
+
+# ── 3-OF-3 MATRIX (full coverage of all 8 cases) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("dom", "ax", "vis", "expected_decision", "expected_escalate"),
+    [
+        (True, True, True, "ok", None),
+        (True, True, False, "fail", None),
+        (True, False, True, "ok_with_warning", None),
+        (True, False, False, "fail", None),
+        (False, True, True, "ok_with_warning", None),
+        (False, True, False, "fail", None),
+        (False, False, True, "fail", None),
+        (False, False, False, "fail_escalate", "cua_pixel_click"),
+    ],
+)
+async def test_matrix_3of3_all_combinations(
+    dom: bool, ax: bool, vis: bool, expected_decision: str, expected_escalate
+) -> None:
+    """Exhaustive matrix test — pin every cell."""
+    result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, dom),
+        channel_ax=_make_channel(AttestationChannel.AX, ax),
+        channel_vis=_make_channel(AttestationChannel.VISION, vis),
+    )
+    assert result.decision == expected_decision, (
+        f"DOM={dom} AX={ax} VIS={vis} expected {expected_decision}, got {result.decision}"
+    )
+    assert result.escalate_to == expected_escalate
+
+
+@pytest.mark.asyncio
+async def test_disagreement_signature_3of3() -> None:
+    """Signature is a clean 3-bit string in DOM-AX-VIS order."""
+    result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, True),
+        channel_ax=_make_channel(AttestationChannel.AX, False),
+        channel_vis=_make_channel(AttestationChannel.VISION, True),
+    )
+    assert result.disagreement_signature == "101"
+
+
+# ── 2-OF-2 FALLBACK (AX explicitly None) ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("dom", "vis", "expected_decision", "expected_escalate"),
+    [
+        (True, True, "ok", None),
+        (True, False, "ok_with_warning", None),
+        (False, True, "ok_with_warning", None),
+        (False, False, "fail_escalate", "cua_pixel_click"),
+    ],
+)
+async def test_2of2_fallback_when_ax_passed_none(
+    dom: bool, vis: bool, expected_decision: str, expected_escalate
+) -> None:
+    """When channel_ax=None, we use the 2-of-2 matrix."""
+    result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, dom),
+        channel_ax=None,
+        channel_vis=_make_channel(AttestationChannel.VISION, vis),
+    )
+    assert result.decision == expected_decision
+    assert result.escalate_to == expected_escalate
+    # Signature must mark AX as unavailable with "_".
+    assert "_" in result.disagreement_signature
+    assert len(result.disagreement_signature) == 3
+    # Only 2 channels in the result list.
+    assert len(result.channels) == 2
+    assert {c.channel for c in result.channels} == {
+        AttestationChannel.DOM,
+        AttestationChannel.VISION,
+    }
+
+
+@pytest.mark.asyncio
+async def test_2of2_signature_format() -> None:
+    """When AX is missing, signature uses '_' for the AX position."""
+    result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, True),
+        channel_ax=None,
+        channel_vis=_make_channel(AttestationChannel.VISION, False),
+    )
+    # DOM=1, AX=_, VIS=0 → "1_0"
+    assert result.disagreement_signature == "1_0"
+
+
+# ── AX UNAVAILABLE AT RUNTIME (not passed-None) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ax_returns_unavailable_falls_back_to_2of2() -> None:
+    """
+    If channel_ax is supplied but reports unavailable=True at runtime
+    (e.g. Chrome lacked --force-renderer-accessibility), we degrade
+    to the 2-of-2 matrix automatically.
+    """
+
+    async def ax_unavailable() -> ChannelResult:
+        return ChannelResult(
+            channel=AttestationChannel.AX,
+            observed_change=False,
+            unavailable=True,
+            detail="ax_tree_disabled",
+        )
+
+    result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, True),
+        channel_ax=ax_unavailable,
+        channel_vis=_make_channel(AttestationChannel.VISION, True),
+    )
+    # 2-of-2 with both observed → ok (not "ok_with_warning"!)
+    assert result.decision == "ok"
+    # But the result list keeps the AX entry so logs can see it.
+    assert len(result.channels) == 3
+    ax_entry = next(c for c in result.channels if c.channel == AttestationChannel.AX)
+    assert ax_entry.unavailable is True
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_unavailable_counts_as_disagree() -> None:
+    """
+    With treat_unavailable_as_disagree=True, an unavailable AX channel
+    is treated as observed_change=False in the 3-of-3 matrix instead of
+    triggering 2-of-2 fallback.
+    """
+
+    async def ax_unavailable() -> ChannelResult:
+        return ChannelResult(
+            channel=AttestationChannel.AX,
+            observed_change=False,
+            unavailable=True,
+            detail="strict",
+        )
+
+    cfg = AttestationConfig(treat_unavailable_as_disagree=True)
+    result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, True),
+        channel_ax=ax_unavailable,
+        channel_vis=_make_channel(AttestationChannel.VISION, True),
+        config=cfg,
+    )
+    # (T, F, T) in 3-of-3 → ok_with_warning, NOT plain ok.
+    assert result.decision == "ok_with_warning"
+
+
+# ── FAILURE MODES (channel raises / times out) ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_channel_exception_is_caught_as_unavailable() -> None:
+    """A raising channel must NOT crash verify_triple."""
+    result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, True),
+        channel_ax=_failing_channel(AttestationChannel.AX),
+        channel_vis=_make_channel(AttestationChannel.VISION, True),
+    )
+    # AX unavailable → 2-of-2 with DOM+VIS both T → ok.
+    assert result.decision == "ok"
+    ax_entry = next(c for c in result.channels if c.channel == AttestationChannel.AX)
+    assert ax_entry.unavailable is True
+    assert "RuntimeError" in ax_entry.detail
+
+
+@pytest.mark.asyncio
+async def test_channel_timeout_is_caught_as_unavailable() -> None:
+    """A slow channel must be killed by the per-channel timeout."""
+    cfg = AttestationConfig(per_channel_timeout_ms=20, total_timeout_ms=200)
+    result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, True),
+        channel_ax=_slow_channel(AttestationChannel.AX, True, delay_ms=200),
+        channel_vis=_make_channel(AttestationChannel.VISION, True),
+        config=cfg,
+    )
+    # AX times out → degrades to 2-of-2 → ok.
+    assert result.decision == "ok"
+    ax_entry = next(c for c in result.channels if c.channel == AttestationChannel.AX)
+    assert ax_entry.unavailable is True
+    assert "timeout" in ax_entry.detail.lower()
+
+
+# ── LATENCY / PARALLELISM ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_channels_run_in_parallel() -> None:
+    """
+    Three 50 ms channels via gather should complete in ~50 ms, not 150 ms.
+    Pads for CI jitter: assert < 120 ms.
+    """
+    cfg = AttestationConfig(per_channel_timeout_ms=200, total_timeout_ms=200)
+    result = await verify_triple(
+        channel_dom=_slow_channel(AttestationChannel.DOM, True, delay_ms=50),
+        channel_ax=_slow_channel(AttestationChannel.AX, True, delay_ms=50),
+        channel_vis=_slow_channel(AttestationChannel.VISION, True, delay_ms=50),
+        config=cfg,
+    )
+    assert result.decision == "ok"
+    assert result.duration_ms < 120, (
+        f"expected parallel ~50 ms, got {result.duration_ms} ms"
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_channel_latency_recorded() -> None:
+    """Each channel result must carry latency_ms ≥ 0."""
+    result = await verify_triple(
+        channel_dom=_slow_channel(AttestationChannel.DOM, True, delay_ms=10),
+        channel_ax=_slow_channel(AttestationChannel.AX, True, delay_ms=10),
+        channel_vis=_slow_channel(AttestationChannel.VISION, True, delay_ms=10),
+    )
+    for c in result.channels:
+        assert c.latency_ms >= 0
+        assert c.latency_ms < 100  # generous upper bound for CI
+
+
+# ── RESULT SHAPE INVARIANTS ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_result_channels_are_ordered_dom_ax_vis() -> None:
+    """Result channel list is in a stable order: DOM, AX, VIS."""
+    result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, True),
+        channel_ax=_make_channel(AttestationChannel.AX, True),
+        channel_vis=_make_channel(AttestationChannel.VISION, True),
+    )
+    order = [c.channel for c in result.channels]
+    assert order == [
+        AttestationChannel.DOM,
+        AttestationChannel.AX,
+        AttestationChannel.VISION,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_result_is_frozen_dataclass() -> None:
+    """AttestationResult is immutable to avoid post-hoc tampering in logs."""
+    result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, True),
+        channel_ax=_make_channel(AttestationChannel.AX, True),
+        channel_vis=_make_channel(AttestationChannel.VISION, True),
+    )
+    with pytest.raises((AttributeError, TypeError, Exception)):
+        result.decision = "fail"  # type: ignore[misc]
+
+
+# ── escalate_to FIELD INVARIANTS ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_escalate_to_only_set_for_fail_escalate() -> None:
+    """escalate_to must be None for everything except fail_escalate."""
+    # Build an ok-result.
+    ok_result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, True),
+        channel_ax=_make_channel(AttestationChannel.AX, True),
+        channel_vis=_make_channel(AttestationChannel.VISION, True),
+    )
+    assert ok_result.escalate_to is None
+
+    # Build a fail (not escalate) result.
+    fail_result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, True),
+        channel_ax=_make_channel(AttestationChannel.AX, True),
+        channel_vis=_make_channel(AttestationChannel.VISION, False),  # (T,T,F)→fail
+    )
+    assert fail_result.decision == "fail"
+    assert fail_result.escalate_to is None
+
+    # Build a fail_escalate result.
+    esc_result = await verify_triple(
+        channel_dom=_make_channel(AttestationChannel.DOM, False),
+        channel_ax=_make_channel(AttestationChannel.AX, False),
+        channel_vis=_make_channel(AttestationChannel.VISION, False),
+    )
+    assert esc_result.decision == "fail_escalate"
+    assert esc_result.escalate_to == "cua_pixel_click"

--- a/survey-cli/tests/test_visual_hash.py
+++ b/survey-cli/tests/test_visual_hash.py
@@ -1,0 +1,238 @@
+"""
+Tests for survey.reliability.visual_hash (SR-168 Phase 2A).
+
+What we verify:
+  - Determinism: same bytes → same hash, always.
+  - Identity: identical images → distance 0.
+  - Robustness: tiny jitter / re-encode / scale → small distance (≤ 5).
+  - Sensitivity: structural change → large distance (≥ 10).
+  - Hamming-distance correctness on hand-picked bit patterns.
+  - DCT internal math against scipy ground truth (skipped if scipy absent).
+  - Edge cases: tiny image, non-square, color, transparent.
+"""
+
+from __future__ import annotations
+
+import io
+import pytest
+from PIL import Image, ImageDraw
+
+from survey.reliability.visual_hash import (
+    DCT_SIZE,
+    HASH_SIZE,
+    dct_hash,
+    hamming_distance,
+    _dct1,
+    _dct2,
+)
+
+
+# -----------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------
+
+
+def _make_png(size: tuple[int, int] = (200, 200), fill: str = "white") -> bytes:
+    img = Image.new("RGB", size, fill)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_checkbox_png(*, checked: bool, size: tuple[int, int] = (200, 200)) -> bytes:
+    img = Image.new("RGB", size, "white")
+    draw = ImageDraw.Draw(img)
+    # Frame
+    draw.rectangle([50, 50, 150, 150], outline="black", width=3)
+    if checked:
+        draw.line([55, 100, 95, 140], fill="black", width=6)
+        draw.line([95, 140, 145, 55], fill="black", width=6)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _shift_png_by(png: bytes, dx: int, dy: int) -> bytes:
+    img = Image.open(io.BytesIO(png))
+    shifted = Image.new(img.mode, img.size, "white")
+    shifted.paste(img, (dx, dy))
+    buf = io.BytesIO()
+    shifted.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+# -----------------------------------------------------------------------
+# Determinism + identity
+# -----------------------------------------------------------------------
+
+
+def test_dct_hash_is_deterministic() -> None:
+    png = _make_checkbox_png(checked=True)
+    assert dct_hash(png) == dct_hash(png)
+
+
+def test_dct_hash_identical_images_same_hash() -> None:
+    png_a = _make_checkbox_png(checked=True)
+    png_b = _make_checkbox_png(checked=True)  # re-rendered, same bytes
+    assert hamming_distance(dct_hash(png_a), dct_hash(png_b)) == 0
+
+
+def test_dct_hash_returns_64bit_int() -> None:
+    h = dct_hash(_make_checkbox_png(checked=True))
+    assert isinstance(h, int)
+    assert 0 <= h < (1 << 64)
+
+
+# -----------------------------------------------------------------------
+# Robustness (small distance for small changes)
+# -----------------------------------------------------------------------
+
+
+def test_dct_hash_robust_to_1px_jitter() -> None:
+    """A 1-px translation must not look like a 'structural' change."""
+    base = _make_checkbox_png(checked=True)
+    jittered = _shift_png_by(base, 1, 1)
+    distance = hamming_distance(dct_hash(base), dct_hash(jittered))
+    # Empirically ≤ 4 on Lanczos-resampled inputs.
+    assert distance <= 6, f"1-px jitter should give distance ≤ 6, got {distance}"
+
+
+def test_dct_hash_robust_to_re_encode() -> None:
+    """PNG re-encode (same pixels, different metadata) → distance 0."""
+    base = _make_checkbox_png(checked=True)
+    img = Image.open(io.BytesIO(base))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    re_encoded = buf.getvalue()
+    assert hamming_distance(dct_hash(base), dct_hash(re_encoded)) == 0
+
+
+def test_dct_hash_color_to_grayscale_invariant() -> None:
+    """Color and grayscale of the same content must hash near-identically."""
+    rgb_png = _make_checkbox_png(checked=True)
+    img = Image.open(io.BytesIO(rgb_png)).convert("L")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    gray_png = buf.getvalue()
+    # Same content; allow up to 2 bits for re-quantisation noise.
+    assert hamming_distance(dct_hash(rgb_png), dct_hash(gray_png)) <= 2
+
+
+# -----------------------------------------------------------------------
+# Sensitivity (large distance for structural changes)
+# -----------------------------------------------------------------------
+
+
+def test_dct_hash_detects_checkbox_state_change() -> None:
+    """The whole point: checked vs unchecked must differ clearly."""
+    unchecked = _make_checkbox_png(checked=False)
+    checked = _make_checkbox_png(checked=True)
+    distance = hamming_distance(dct_hash(unchecked), dct_hash(checked))
+    assert distance >= 8, f"state change should give distance ≥ 8, got {distance}"
+
+
+def test_dct_hash_detects_appear_disappear() -> None:
+    """Empty white box → box with content must look very different."""
+    blank = _make_png(fill="white")
+    with_content = _make_checkbox_png(checked=True)
+    distance = hamming_distance(dct_hash(blank), dct_hash(with_content))
+    assert distance >= 10, f"appear should give distance ≥ 10, got {distance}"
+
+
+# -----------------------------------------------------------------------
+# Hamming distance correctness
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        (0, 0, 0),
+        (0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0),
+        (0, 0xFFFFFFFFFFFFFFFF, 64),
+        (0xF0, 0x0F, 8),
+        (0x1, 0x2, 2),
+        (0xAA, 0x55, 8),
+    ],
+)
+def test_hamming_distance_correct(a: int, b: int, expected: int) -> None:
+    assert hamming_distance(a, b) == expected
+
+
+def test_hamming_distance_symmetric() -> None:
+    a = dct_hash(_make_checkbox_png(checked=True))
+    b = dct_hash(_make_checkbox_png(checked=False))
+    assert hamming_distance(a, b) == hamming_distance(b, a)
+
+
+# -----------------------------------------------------------------------
+# DCT internals (sanity)
+# -----------------------------------------------------------------------
+
+
+def test_dct1_dc_only_for_constant_signal() -> None:
+    """A constant signal has all energy in the DC coefficient."""
+    import numpy as np
+
+    x = np.ones((8,), dtype=np.float64)
+    result = _dct1(x)
+    # k=0 (DC) holds all energy; k>=1 ≈ 0.
+    assert abs(result[0]) > 1e-3
+    assert max(abs(v) for v in result[1:]) < 1e-9
+
+
+def test_dct2_preserves_shape() -> None:
+    import numpy as np
+
+    x = np.random.RandomState(42).rand(DCT_SIZE, DCT_SIZE)
+    result = _dct2(x)
+    assert result.shape == (DCT_SIZE, DCT_SIZE)
+
+
+# -----------------------------------------------------------------------
+# Edge cases
+# -----------------------------------------------------------------------
+
+
+def test_dct_hash_tiny_image() -> None:
+    """8×8 input image (smaller than DCT_SIZE) — must still produce a hash."""
+    png = _make_checkbox_png(checked=True, size=(8, 8))
+    h = dct_hash(png)
+    assert 0 <= h < (1 << 64)
+
+
+def test_dct_hash_non_square_image() -> None:
+    png = _make_checkbox_png(checked=True, size=(300, 100))
+    h = dct_hash(png)
+    assert 0 <= h < (1 << 64)
+
+
+def test_dct_hash_uniform_region_is_deterministic_pure_noise() -> None:
+    """
+    Documented limit: uniform regions produce a deterministic but
+    *noise-driven* hash (rounding artifacts from grayscale conversion +
+    Lanczos resampling dominate the high-frequency bits).
+
+    What this test pins:
+      1. Reproducibility: same flat color → same hash, every time.
+      2. Caveat: distance between two different flat colors is NOT
+         predictable — it's noise, not signal. Callers MUST detect
+         "uniform input" upstream (e.g. check std-dev of the source
+         region) before trusting the hash.
+
+    See dct_hash() docstring → "KNOWN LIMITS".
+    """
+    white_a = _make_png(fill="white")
+    white_b = _make_png(fill="white")  # re-rendered, byte-identical
+    assert dct_hash(white_a) == dct_hash(white_b)
+
+
+# -----------------------------------------------------------------------
+# Constants
+# -----------------------------------------------------------------------
+
+
+def test_hash_size_constants_consistent() -> None:
+    # 64 bits = HASH_SIZE² (minus DC, plus reserved LSB).
+    assert HASH_SIZE * HASH_SIZE == 64
+    assert DCT_SIZE >= HASH_SIZE


### PR DESCRIPTION
# SR-168 Phase 2B — Attestation Core (PR B of 3)

> **Stacked on PR A (#209)**. Merge order: #209 → this → PR C.
> If #209 lands first, GitHub will auto-rebase this onto main.

## What this PR does

Adds `survey/reliability/attestation.py` — the **backend-agnostic core** of triple-channel verification.

Channels are async callables injected at call site. This module knows nothing about playwright, CDP, AX-trees, or screenshots — those are PR C's job. That separation gives us:

- **23 deterministic unit tests** with mocked channels (no browser fixtures)
- **Reusable in CLI + Daemon** without code drift
- **Drop-in replaceable** if we ever swap browser drivers

## API at a glance

```python
result = await verify_triple(
    channel_dom=my_dom_fn,
    channel_ax=my_ax_fn,     # or None → 2-of-2 fallback
    channel_vis=my_vis_fn,
)

if result.decision == "ok":
    proceed()
elif result.decision == "ok_with_warning":
    log_warning(result.disagreement_signature)
    proceed()
elif result.decision == "fail":
    retry()
elif result.decision == "fail_escalate":
    cua_pixel_click_fallback()  # result.escalate_to == "cua_pixel_click"
```

## Disagreement matrix (pinned to tests, all 8 rows)

| DOM | AX | VIS | decision | escalate |
|:---:|:--:|:---:|---|---|
| T | T | T | ok | — |
| T | T | F | fail | — |
| T | F | T | ok_with_warning | — |
| T | F | F | fail | — |
| F | T | T | ok_with_warning | — |
| F | T | F | fail | — |
| F | F | T | fail | — |
| F | F | F | fail_escalate | cua_pixel_click |

## 2-of-2 fallback (AX unavailable)

Triggers in 3 cases:
1. `channel_ax=None` explicitly passed (e.g. Chrome without `--force-renderer-accessibility`)
2. AX channel returns `unavailable=True` at runtime
3. AX channel raises or times out

Matrix:
| DOM | VIS | decision |
|:---:|:---:|---|
| T | T | ok |
| T | F | ok_with_warning |
| F | T | ok_with_warning |
| F | F | fail_escalate |

## Channel safety

`_run_channel_safe()` wraps each injected channel:
- Per-channel `asyncio.wait_for()` timeout (default 300 ms)
- Catches all exceptions → `unavailable=True` with `detail="channel_error: ExceptionClass: msg"`
- Records latency even on timeout/error

No channel can crash `verify_triple()`.

## Test coverage

```
$ pytest tests/test_attestation.py -q
23 passed in 0.19s
```

- 8 parametrized matrix tests (3-of-3 full)
- 4 parametrized fallback tests (2-of-2 full)
- 6 failure-mode + edge tests
- 5 invariant + latency tests

## What's NOT in this PR (handled in PR C)

- `attestation_channels.py` with the actual CDP/AX/Pillow implementations
- Integration into `verifier.py` (`safe_executor` pre-action snapshot caching)
- E2E test with real Heypiggy survey
- Structured-log sink for disagreement events (will follow #190 structlog Phase 1)

## CI checks expected

- [x] ruff (clean locally on both files)
- [x] path-guard (lives under `survey-cli/survey/reliability/` per AGENTS.md)
- [x] mypy (informational — minimal new types, all annotated)
- [x] tests 3.12 + 3.13

## Linked

- Parent: #168 (SR-168 triple-channel attestation)
- Stacked on: #209 (PR A — visual_hash.py)
- Successor: PR C (verifier + safe_executor integration)
- Done-Definition: #212

## Owner

Agent One. Implementation from the spec posted to #168 on 2026-05-13.
