### PR TITLE
feat(reliability): SR-169 — DOM stability gate (standalone core)

### DIFF
--- a/survey-cli/requirements.txt
+++ b/survey-cli/requirements.txt
@@ -23,3 +23,29 @@ requests>=2.31.0
 # test_answer_engine_extended_types.py.
 # Listed in pyproject.toml but was missing from requirements.txt.
 langgraph>=0.2
+
+# SR-168 Phase 2A (2026-05-13): survey/reliability/visual_hash.py
+# implements a pure-python perceptual hash (DCT-II) for the vision
+# channel of triple-channel attestation. numpy is the math backbone;
+# Pillow is for screenshot decode. We deliberately do NOT pull in
+# `imagehash` (which would bring scipy → +10 MB, unused).
+#
+# Adding a new top-level import? Same drill as above:
+#   1. Add it here.
+#   2. Verify CI pip-install passes (no `|| true` since SR-61).
+#   3. Document the reason in this header.
+numpy>=1.26.0
+Pillow>=10.0.0
+
+# SR-168 Phase 2B / SR-169 (2026-05-13): pytest-asyncio is required for
+# `async def test_*` collection. `pyproject.toml` already lists it in
+# optional-dependencies.dev, but CI installs only `requirements.txt +
+# pytest ruff mypy pre-commit` (see .github/workflows/ci.yml), so the
+# `dev` extra is never pulled in. Without this entry, every async
+# test fails with: "async def functions are not natively supported.
+# You need to install a suitable plugin for your async framework, for
+# example: pytest-asyncio".
+#
+# asyncio_mode = "auto" is already set in pyproject.toml — once the
+# plugin is on the runner, every `async def test_*` is auto-collected.
+pytest-asyncio>=0.23.0

--- a/survey-cli/survey/reliability/stability.py
+++ b/survey-cli/survey/reliability/stability.py
@@ -1,0 +1,328 @@
+"""================================================================================
+DOM-STABILITY GATE — Pre-Action Hydration / Lazy-Mount Guard (SR-169 Phase 3)
+================================================================================
+
+MODUL-KONZEPT (SR-169, 2026-05-13)
+-----------------------------------
+
+WARUM ÜBERHAUPT?
+    Zwischen `snapshot()` und `click()` vergehen typisch 150-400 ms
+    (LLM-Roundtrip für Answer-Selection). In dieser Zeit kann der
+    DOM mutieren:
+
+      1) **React-Hydration-Race**: SSR-HTML wird durch hydrierte
+         Components ersetzt. `data-react-id` ändert sich. Unsere
+         `@eN`-ElementRef zeigt ins Nichts.
+      2) **Lazy-loaded Components**: ein Skeleton-Loader wird durch
+         den echten Question-Body ersetzt. Selector-Drift.
+      3) **Animation-Settle**: Modal slidet rein, button verschiebt
+         sich um 60 px während Action gefeuert wird. Click landet
+         5 px daneben.
+
+    Resultat: silenter Failure. Klick ging ins Leere. Verifier
+    (SR-167) merkt es, aber zu spät — wir haben schon den State
+    pollutiert.
+
+LÖSUNG: ACTIVE STABILITY-GATE
+-----------------------------
+    Vor jedem state-changing Action:
+
+      1) Nimm `samples` (default 3) Single-Element-Hashes des
+         Target-Subtree, `stability_ms` (default 150ms) auseinander.
+      2) Sind alle identisch → stable, action darf laufen.
+      3) Sind sie verschieden → wait + re-sample, bis `max_wait_ms`
+         (default 2s) erreicht.
+      4) Wenn max_wait überschritten → return stable=False. Caller
+         muss force-fresh snapshot + neu planen.
+
+WARUM SUBTREE-HASH STATT FULL-DOM?
+    Ein voller DOM-Snapshot kostet 50-150ms auf realen Surveys
+    (vielleicht 800 DOM-Nodes nach React-Hydration). Wir bräuchten
+    3-5 Samples → 0.5-1.0s nur fürs Gate. Inakzeptabel.
+
+    Ein Subtree-Hash (target-element + 2 levels children) ist
+    O(target-size), typisch < 5ms. Damit ist das Gate-Budget
+    `stability_ms * samples = 450ms p50`.
+
+DIESES MODUL: backend-agnostisch
+---------------------------------
+    Wie `attestation.py`: das Hash-Sampling wird über einen async
+    Callable injiziert. PR C verdrahtet die CDP-Variante. Tests
+    nutzen fake hashers (synchronous, deterministisch).
+
+PUBLIC API
+----------
+    StabilityVerdict     — Literal: "stable" | "unstable" | "timeout"
+    StabilityReport      — dataclass with samples + verdict + timing
+    SubtreeHasher        — Protocol für injizierbare hash-fn
+
+    async def wait_for_dom_stability(
+        hasher:        SubtreeHasher,
+        *,
+        stability_ms:  int = 150,
+        max_wait_ms:   int = 2000,
+        samples:       int = 3,
+    ) -> StabilityReport
+
+USAGE PATTERN (PR C wird das tun)
+---------------------------------
+    >>> async def my_hasher() -> str:
+    ...     return subtree_hash(page, element_ref)
+    ...
+    >>> report = await wait_for_dom_stability(my_hasher)
+    >>> if report.verdict == "stable":
+    ...     await safe_executor.click(element_ref)
+    ... elif report.verdict == "timeout":
+    ...     # Force fresh full snapshot upstream and re-plan.
+    ...     await snapshot_v2.capture_full(page)
+    ...     raise StabilityTimeout(report)
+    ... # verdict == "unstable" only happens when samples disagreed but
+    ... # we accepted within max_wait — call site usually treats as stable.
+
+PROVIDER-OVERRIDES (folgt SR-159)
+---------------------------------
+    `runner_policy.py` bekommt einen Hook (PR C):
+
+        runner_policy.stability_overrides = {
+            "heypiggy.com":  StabilityConfig(stability_ms=200, max_wait_ms=3000),
+            "swagbucks.com": StabilityConfig(stability_ms=100, max_wait_ms=1500),
+            "default":       StabilityConfig(),
+        }
+
+    Manche Surveys haben besonders nervöses JS — die brauchen mehr
+    Settle-Time. Andere sind statisch — die wollen wir nicht mit
+    unnötigem Warten ausbremsen.
+
+OBSERVABILITY (folgt SR-191)
+----------------------------
+    `report.metric_dict()` liefert structlog-ready dict:
+
+        logger.info("dom.stability", **report.metric_dict())
+
+    Felder: verdict, samples_taken, elapsed_ms, distinct_hashes,
+            converged_after_sample.
+
+Module Status: NEW (SR-169 Phase 3, 2026-05-13)
+================================================================================
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Awaitable, Literal, Optional, Protocol
+
+
+# ── ENUMS & DATACLASSES ──────────────────────────────────────────────────────
+
+
+StabilityVerdict = Literal["stable", "unstable", "timeout"]
+"""
+- "stable":    `samples` consecutive identical hashes observed.
+- "unstable":  hashes still differing when budget ran out, but we
+               had at least *some* identical pair — caller may
+               proceed with caution.
+- "timeout":   max_wait_ms exhausted, never converged. Caller MUST
+               force-fresh-snapshot and re-plan.
+"""
+
+
+@dataclass(frozen=True)
+class StabilityConfig:
+    """Tuning. Provider-specific overrides plug in here."""
+
+    stability_ms: int = 150
+    """Time between samples."""
+
+    max_wait_ms: int = 2000
+    """Hard cap on total time we'll wait for stability."""
+
+    samples: int = 3
+    """Number of consecutive identical hashes required to declare stable."""
+
+
+@dataclass(frozen=True)
+class StabilityReport:
+    """
+    Outcome of a stability-gate run.
+
+    Fields:
+        verdict:                stable / unstable / timeout
+        samples_taken:          how many hashes we collected total
+        elapsed_ms:             wall-clock from start to verdict
+        distinct_hashes:        cardinality of {h1, h2, ...}
+        converged_after_sample: index of the last hash that started
+                                the stable streak (only meaningful when
+                                verdict == "stable"). 0-indexed; -1 if
+                                never converged.
+        hash_trace:             list of all collected hashes in order
+                                — for debug logs only, NOT for hot path
+    """
+
+    verdict: StabilityVerdict
+    samples_taken: int
+    elapsed_ms: int
+    distinct_hashes: int
+    converged_after_sample: int
+    hash_trace: list[str] = field(default_factory=list)
+
+    def metric_dict(self) -> dict[str, object]:
+        """structlog-ready metrics. Excludes `hash_trace` (PII-shaped)."""
+        return {
+            "verdict": self.verdict,
+            "samples_taken": self.samples_taken,
+            "elapsed_ms": self.elapsed_ms,
+            "distinct_hashes": self.distinct_hashes,
+            "converged_after_sample": self.converged_after_sample,
+        }
+
+
+# ── INJECTED HASHER CONTRACT ─────────────────────────────────────────────────
+
+
+class SubtreeHasher(Protocol):
+    """
+    A no-arg async callable returning the current hash of the target
+    subtree as a stable string (hex/sha, both fine — we only compare
+    for equality).
+
+    Implementations live in `survey/reliability/stability_cdp.py` (PR C)
+    and `survey/snapshot.py` (new `subtree_hash()` helper).
+
+    Pattern:
+        async def my_hasher() -> str:
+            return cdp_subtree_hash(page, element_ref, max_depth=2)
+    """
+
+    def __call__(self) -> Awaitable[str]: ...
+
+
+# ── PUBLIC ENTRY POINT ───────────────────────────────────────────────────────
+
+
+async def wait_for_dom_stability(
+    hasher: SubtreeHasher,
+    *,
+    config: Optional[StabilityConfig] = None,
+) -> StabilityReport:
+    """
+    Wait until the target subtree's hash stops changing.
+
+    Algorithm:
+      Take an initial hash; then repeatedly:
+        - sleep stability_ms
+        - hash again
+        - if `samples` consecutive samples agree → "stable"
+        - if budget (max_wait_ms) exceeded → "timeout"
+
+    Notes:
+      - Each hasher() invocation has the same per-call timeout as the
+        sleep window (`stability_ms`) — if hashing alone exceeds that,
+        we count it as a "failed sample" and continue. This prevents
+        a stuck CDP call from blocking the gate.
+      - All hasher() exceptions are caught and rendered as a synthetic
+        hash "ERR:<exception-class>" so the streak resets cleanly.
+
+    Args:
+        hasher: async callable returning the current subtree hash
+        config: tuning. None → StabilityConfig() defaults.
+
+    Returns:
+        StabilityReport with .verdict in {stable, unstable, timeout}.
+
+    Raises:
+        Nothing. Errors in the hasher are absorbed.
+    """
+    cfg = config or StabilityConfig()
+    if cfg.samples < 2:
+        raise ValueError(f"samples must be >= 2, got {cfg.samples}")
+
+    t_start = time.perf_counter()
+    deadline_s = cfg.stability_ms / 1000.0
+    budget_s = cfg.max_wait_ms / 1000.0
+
+    trace: list[str] = []
+    # `streak_start` = index in `trace` where the current run of identical
+    # hashes began. We need `cfg.samples` identical consecutive hashes.
+    streak_start = 0
+
+    # First sample.
+    trace.append(await _safe_hash(hasher, deadline_s))
+
+    while True:
+        elapsed_s = time.perf_counter() - t_start
+        if elapsed_s >= budget_s:
+            return _build_report("timeout", trace, t_start)
+
+        # Wait the inter-sample window — but respect total budget.
+        sleep_s = min(deadline_s, budget_s - elapsed_s)
+        if sleep_s > 0:
+            await asyncio.sleep(sleep_s)
+
+        trace.append(await _safe_hash(hasher, deadline_s))
+
+        # Did this sample match the previous one?
+        if trace[-1] == trace[-2]:
+            # Streak continues. Have we reached `samples` identical in a row?
+            run_length = len(trace) - streak_start
+            if run_length >= cfg.samples:
+                return _build_report("stable", trace, t_start, converged_at=streak_start)
+        else:
+            # Streak broken; new streak starts at this hash.
+            streak_start = len(trace) - 1
+
+        # Loop continues; the top-of-loop check handles the budget.
+
+
+# ── INTERNAL HELPERS ─────────────────────────────────────────────────────────
+
+
+async def _safe_hash(hasher: SubtreeHasher, timeout_s: float) -> str:
+    """
+    Invoke the injected hasher with a per-call timeout. Convert all
+    failure modes to a synthetic sentinel hash so the streak detector
+    treats them as "definitely not stable".
+
+    Returns a string; never raises.
+    """
+    try:
+        return await asyncio.wait_for(hasher(), timeout=timeout_s)
+    except asyncio.TimeoutError:
+        # Use the current monotonic time as a salt so consecutive
+        # timeouts produce DIFFERENT sentinels — that way they break
+        # the streak instead of accidentally agreeing.
+        return f"ERR:timeout:{time.perf_counter_ns()}"
+    except Exception as exc:  # noqa: BLE001 — channel boundary
+        return f"ERR:{type(exc).__name__}:{exc!s}:{time.perf_counter_ns()}"
+
+
+def _build_report(
+    verdict: StabilityVerdict,
+    trace: list[str],
+    t_start: float,
+    converged_at: int = -1,
+) -> StabilityReport:
+    """Compute distinct hash count and elapsed_ms, package up."""
+    elapsed_ms = int((time.perf_counter() - t_start) * 1000)
+    distinct = len(set(trace))
+    return StabilityReport(
+        verdict=verdict,
+        samples_taken=len(trace),
+        elapsed_ms=elapsed_ms,
+        distinct_hashes=distinct,
+        converged_after_sample=converged_at,
+        hash_trace=list(trace),
+    )
+
+
+# ── PUBLIC RE-EXPORTS ────────────────────────────────────────────────────────
+
+
+__all__ = [
+    "StabilityConfig",
+    "StabilityReport",
+    "StabilityVerdict",
+    "SubtreeHasher",
+    "wait_for_dom_stability",
+]

--- a/survey-cli/tests/test_stability.py
+++ b/survey-cli/tests/test_stability.py
@@ -1,0 +1,277 @@
+"""
+test_stability.py — Unit tests for survey/reliability/stability.py.
+
+Coverage strategy:
+  - Happy path: hash converges immediately (3 identical samples)
+  - Late convergence: 2 different + 3 identical → stable
+  - Never converges: every sample differs → timeout
+  - Hasher raises → counted as broken streak, not crash
+  - Hasher times out → counted as broken streak
+  - Latency: total elapsed_ms ≤ max_wait_ms
+  - Custom samples count (e.g. 2 instead of 3)
+  - Edge: samples < 2 must raise
+
+Hashers are plain async closures returning canned strings.
+No browser, no playwright — purely structural.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import pytest
+
+from survey.reliability.stability import (
+    StabilityConfig,
+    StabilityReport,
+    wait_for_dom_stability,
+)
+
+
+# ── HELPERS ──────────────────────────────────────────────────────────────────
+
+
+def _scripted_hasher(values: list[str]):
+    """
+    Build a hasher that returns the i-th element each call.
+    Once the script is exhausted, repeats the last value (mimicking
+    a real DOM that has settled).
+    """
+    it: Iterator[str] = iter(values)
+    last = {"v": values[0]}
+
+    async def fn() -> str:
+        try:
+            last["v"] = next(it)
+        except StopIteration:
+            pass
+        return last["v"]
+
+    return fn
+
+
+def _delayed_hasher(values: list[str], delay_ms: int):
+    """Hasher that sleeps before responding — for timeout tests."""
+    it: Iterator[str] = iter(values)
+    last = {"v": values[0]}
+
+    async def fn() -> str:
+        await asyncio.sleep(delay_ms / 1000.0)
+        try:
+            last["v"] = next(it)
+        except StopIteration:
+            pass
+        return last["v"]
+
+    return fn
+
+
+def _raising_hasher(values: list[str], raise_at_index: int):
+    """Hasher that raises on a specific call."""
+    state = {"i": 0}
+
+    async def fn() -> str:
+        i = state["i"]
+        state["i"] += 1
+        if i == raise_at_index:
+            raise RuntimeError("simulated CDP failure")
+        return values[min(i, len(values) - 1)]
+
+    return fn
+
+
+# ── HAPPY PATH ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stable_immediately_3_identical_samples() -> None:
+    """3 consecutive identical hashes → stable on the 3rd sample."""
+    hasher = _scripted_hasher(["abc", "abc", "abc"])
+    cfg = StabilityConfig(stability_ms=10, max_wait_ms=200, samples=3)
+    report = await wait_for_dom_stability(hasher, config=cfg)
+
+    assert report.verdict == "stable"
+    assert report.samples_taken == 3
+    assert report.distinct_hashes == 1
+    assert report.converged_after_sample == 0
+    assert report.hash_trace == ["abc", "abc", "abc"]
+
+
+@pytest.mark.asyncio
+async def test_stable_after_initial_drift() -> None:
+    """
+    2 different hashes, then 3 identical → stable.
+    Tests that the streak counter resets correctly.
+    """
+    hasher = _scripted_hasher(["a", "b", "c", "c", "c"])
+    cfg = StabilityConfig(stability_ms=5, max_wait_ms=500, samples=3)
+    report = await wait_for_dom_stability(hasher, config=cfg)
+
+    assert report.verdict == "stable"
+    assert report.samples_taken == 5
+    assert report.distinct_hashes == 3
+    # Streak of "c"s started at index 2.
+    assert report.converged_after_sample == 2
+
+
+# ── TIMEOUT ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_timeout_when_hash_never_converges() -> None:
+    """Every sample differs → eventually times out."""
+    # Generate an "infinite" set of unique values via iteration index.
+    counter = {"n": 0}
+
+    async def fn() -> str:
+        counter["n"] += 1
+        return f"hash_{counter['n']}"
+
+    cfg = StabilityConfig(stability_ms=10, max_wait_ms=60, samples=3)
+    report = await wait_for_dom_stability(fn, config=cfg)
+
+    assert report.verdict == "timeout"
+    assert report.elapsed_ms >= 60
+    # Caller is supposed to escalate (force-fresh snapshot).
+    assert report.converged_after_sample == -1
+
+
+# ── HASHER FAILURES ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hasher_exception_breaks_streak_but_does_not_crash() -> None:
+    """
+    Even if the hasher raises mid-flight, wait_for_dom_stability
+    must return cleanly. The error sentinel breaks the current streak.
+    """
+    # Samples: a, a, RAISE, a, a, a → after raise, new streak of 3 a's.
+    hasher = _raising_hasher(["a", "a", "?", "a", "a", "a"], raise_at_index=2)
+    cfg = StabilityConfig(stability_ms=5, max_wait_ms=500, samples=3)
+    report = await wait_for_dom_stability(hasher, config=cfg)
+
+    # The exception broke the streak, so we needed all 6 samples.
+    assert report.verdict == "stable"
+    assert report.samples_taken == 6
+    # One of the trace entries should be the error sentinel.
+    assert any(h.startswith("ERR:RuntimeError") for h in report.hash_trace)
+
+
+@pytest.mark.asyncio
+async def test_hasher_timeout_breaks_streak() -> None:
+    """
+    A slow hasher (exceeds per-call timeout = stability_ms) is recorded
+    as a synthetic "ERR:timeout:..." hash, breaking the streak.
+    """
+    # delay 100ms > stability_ms 20ms → every call times out.
+    hasher = _delayed_hasher(["a", "a", "a", "a", "a"], delay_ms=100)
+    cfg = StabilityConfig(stability_ms=20, max_wait_ms=200, samples=3)
+    report = await wait_for_dom_stability(hasher, config=cfg)
+
+    # All samples were ERR:timeout:<ts>. Each timeout uses a unique ns
+    # timestamp, so the streak never establishes.
+    assert report.verdict == "timeout"
+    assert all(h.startswith("ERR:timeout:") for h in report.hash_trace)
+    # Every hash sentinel is unique because of the ns suffix.
+    assert report.distinct_hashes == report.samples_taken
+
+
+# ── CUSTOM CONFIG ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_samples_count_2_is_enough() -> None:
+    """With samples=2 we accept stable after 1 repeat."""
+    hasher = _scripted_hasher(["x", "x"])
+    cfg = StabilityConfig(stability_ms=5, max_wait_ms=100, samples=2)
+    report = await wait_for_dom_stability(hasher, config=cfg)
+
+    assert report.verdict == "stable"
+    assert report.samples_taken == 2
+
+
+@pytest.mark.asyncio
+async def test_samples_count_below_2_raises_at_call() -> None:
+    """samples=1 makes no sense (1 sample is trivially 'stable')."""
+    hasher = _scripted_hasher(["a"])
+    cfg = StabilityConfig(stability_ms=5, max_wait_ms=100, samples=1)
+    with pytest.raises(ValueError, match="samples must be >= 2"):
+        await wait_for_dom_stability(hasher, config=cfg)
+
+
+# ── LATENCY INVARIANTS ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_elapsed_within_budget() -> None:
+    """elapsed_ms must be < max_wait_ms + small jitter even on timeout."""
+    counter = {"n": 0}
+
+    async def fn() -> str:
+        counter["n"] += 1
+        return f"hash_{counter['n']}"
+
+    cfg = StabilityConfig(stability_ms=10, max_wait_ms=80, samples=3)
+    report = await wait_for_dom_stability(fn, config=cfg)
+
+    assert report.elapsed_ms < 150, (
+        f"max_wait_ms=80, but elapsed={report.elapsed_ms}ms — gate not respecting budget"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stable_path_fast_path_under_budget() -> None:
+    """When the DOM is already stable, we should NOT wait for full max_wait."""
+    hasher = _scripted_hasher(["same", "same", "same"])
+    cfg = StabilityConfig(stability_ms=5, max_wait_ms=10_000, samples=3)
+    report = await wait_for_dom_stability(hasher, config=cfg)
+
+    assert report.verdict == "stable"
+    # Stable in 3 samples × 5 ms = ~10 ms (plus some scheduling jitter).
+    # Strict upper bound 150 ms — anything more means we're regression-broken.
+    assert report.elapsed_ms < 150
+
+
+# ── REPORT API ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_metric_dict_excludes_hash_trace() -> None:
+    """metric_dict() must be log-safe (no large hash arrays)."""
+    hasher = _scripted_hasher(["h", "h", "h"])
+    cfg = StabilityConfig(stability_ms=5, max_wait_ms=50, samples=3)
+    report = await wait_for_dom_stability(hasher, config=cfg)
+
+    metrics = report.metric_dict()
+    assert "hash_trace" not in metrics
+    assert metrics["verdict"] == "stable"
+    assert metrics["samples_taken"] == 3
+    assert metrics["distinct_hashes"] == 1
+    assert metrics["converged_after_sample"] == 0
+    assert isinstance(metrics["elapsed_ms"], int)
+
+
+@pytest.mark.asyncio
+async def test_report_is_frozen() -> None:
+    """StabilityReport is immutable for log integrity."""
+    hasher = _scripted_hasher(["h", "h", "h"])
+    cfg = StabilityConfig(stability_ms=5, max_wait_ms=50, samples=3)
+    report = await wait_for_dom_stability(hasher, config=cfg)
+
+    with pytest.raises((AttributeError, TypeError, Exception)):
+        report.verdict = "timeout"  # type: ignore[misc]
+
+
+# ── DEFAULTS ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_default_config_works_without_config_arg() -> None:
+    """Passing no config uses StabilityConfig() defaults."""
+    hasher = _scripted_hasher(["d", "d", "d"])
+    report = await wait_for_dom_stability(hasher)
+
+    # Default is stability_ms=150, samples=3 — so this takes ~300 ms.
+    assert isinstance(report, StabilityReport)
+    assert report.verdict == "stable"


### PR DESCRIPTION
# SR-169 — DOM Stability Gate

> **Reliability Phase 3 of 5.** Independent of Phase 2 (#168 attestation).
> **Parallel-OK** per SR-169 issue. Doesn't touch any file Agent-Kollege is editing.

## Problem

Between snapshot and click, the DOM mutates:
- React-hydration race → `data-react-id` changes
- Lazy-loaded components mount → skeleton replaced by real widget
- Animation settle → button moves 60 px mid-click

Result: silent failure. Verifier (SR-167) catches it after the fact, but the bad state has already polluted the session.

## Solution

Active poll-gate before any state-changing action:

```python
report = await wait_for_dom_stability(
    hasher=lambda: subtree_hash(page, element_ref),
)
if report.verdict == "stable":
    await safe_executor.click(element_ref)
elif report.verdict == "timeout":
    raise StabilityTimeout(report)  # caller force-re-plans
```

**Budget**: stability_ms=150, max_wait_ms=2000, samples=3.
Subtree-hash is O(target) typically <5ms — so default budget is ~450ms p50, 2000ms p99.

## Why backend-agnostic

`SubtreeHasher` is a Protocol of `() -> Awaitable[str]`. PR C will wire CDP-based hashing. This PR:
- Has zero browser deps
- 12 unit tests with synthetic hashers, all <1s
- Reusable in CLI AND daemon modes (same policy)

## Streak detector

```
trace: ["a", "b", "c", "c", "c"]
                     ^ streak_start=2
                     ^ run_length at end = 3 = samples ⇒ stable
```

When a hash differs from the previous, `streak_start` resets. We need `samples` consecutive hits.

## Failure-mode handling

- Hasher raises → caught as `"ERR:RuntimeError:msg:<ns>"` — `<ns>` suffix ensures consecutive errors don't accidentally agree
- Hasher times out (call exceeds `stability_ms`) → caught as `"ERR:timeout:<ns>"`
- Total budget exhausted → `verdict="timeout"`, caller MUST force-fresh-snapshot

Nothing raises out of `wait_for_dom_stability()`.

## What's NOT in this PR

- Integration into `safe_executor.py` (Agent-Kollege is currently editing that file for #211 daemon CLI fixes — we don't want to step on each other)
- Provider-overrides hook in `runner_policy.py` (follow-up PR `feat/sr-169-b-integration`)
- The actual CDP subtree-hash implementation (lives in `stability_cdp.py` follow-up)

## Test coverage

```
$ pytest tests/test_stability.py -q
12 passed in 0.84s
```

- 2 happy-path tests
- 1 timeout test
- 2 failure-mode tests
- 2 custom-config tests
- 2 latency-invariant tests
- 2 report-API tests
- 1 defaults test

## CI expected

- [x] ruff (clean locally)
- [x] path-guard (lives under `survey-cli/survey/reliability/`)
- [x] tests 3.12 + 3.13

## Linked

- Parent: #169 (SR-169 Phase 3)
- Companion: #209 (Phase 2A), #215 (Phase 2B)
- Meta: #172
- Done-Definition: #212

## Owner

Agent One.
