### PR TITLE
SR-170: Trajectory Judge library + persona quarantine (PR1 of 2)

### DIFF
--- a/prompts/trajectory_audit.txt
+++ b/prompts/trajectory_audit.txt
@@ -1,0 +1,59 @@
+You are an auditor for completed survey-taking trajectories. A survey-taking agent has just finished one online survey while role-playing a fictional persona. Your job is to score the trajectory on four orthogonal dimensions and return a single JSON object.
+
+# Input
+
+You will receive a JSON array under the header "TRAJECTORY (JSON):". Each element is one step the agent took, with at least these fields when applicable: the survey page/question identifier, the question type, the question text (possibly abridged), the answer the agent submitted, optional timing metadata, optional persona context, and any re-do markers.
+
+# Output schema (mandatory)
+
+Return one JSON object — and nothing else. No markdown, no prose before or after, no code fences. Schema:
+
+{
+  "compliance":  <float 0.0..1.0>,
+  "efficiency":  <float 0.0..1.0>,
+  "accuracy":    <float 0.0..1.0>,
+  "coherence":   <float 0.0..1.0>,
+  "rationale":   <string, max 500 chars>
+}
+
+All four score fields are REQUIRED. Each must be a JSON number in the closed interval [0.0, 1.0]. 1.0 means "no problem detected on this dimension"; 0.0 means "severe problem". Use the full range — do not anchor everything near 0.9.
+
+# Dimension definitions
+
+compliance — Did the agent follow the survey's literal instructions?
+  1.0 = every constraint honored (length minimums, required-options, "select all that apply", attention checks).
+  0.0 = ignored explicit instructions, failed attention checks, gave free-text where a list was demanded, etc.
+
+efficiency — Was the trajectory minimal?
+  1.0 = each question answered once, forward-only progression, no re-do cycles.
+  0.0 = same page submitted multiple times, repeated back-navigation, visible thrashing.
+
+accuracy — Are the answers internally consistent with the agent's stated persona?
+  1.0 = every answer plausible for this persona's age, occupation, geography, and self-reported history.
+  0.0 = contradictions across answers (e.g. claims student in Q1, claims 25-year career in Q14), demographically implausible combinations.
+
+coherence — Does the answer sequence look human?
+  1.0 = natural variance in answer choices, varied phrasing in free-text, plausible response-time distribution.
+  0.0 = robotic patterns — always picking option B on Likert scales, identical timing across all questions, copy-pasted free-text, monotonic choices.
+
+# Scoring guidance
+
+- Be conservative. If a trajectory shows even one clear violation on a dimension, drop that dimension below 0.7.
+- Score each dimension INDEPENDENTLY. A trajectory can be compliant but inefficient, or efficient but incoherent.
+- If the trajectory is too short to assess a dimension confidently (e.g. only 2 steps for coherence), score it at exactly 0.5 and say so in the rationale.
+- The rationale should cite at least one specific step index when a score is below 0.7.
+
+# Anti-patterns to flag aggressively
+
+- Re-doing the same page more than twice (efficiency).
+- Free-text answers that are verbatim copies across steps (coherence).
+- Demographic answer in step N contradicted by another demographic answer in step M (accuracy).
+- Skipping required questions or "submitting" without an answer (compliance).
+- Step-to-step timing that is suspiciously uniform, e.g. exactly 2.0 s between every submission (coherence).
+
+# Important constraints
+
+- Do not invent fields not in the input. If a step lacks timing, don't guess.
+- Do not judge whether the persona itself is "good" — judge how well the trajectory honors the persona that was given.
+- If the persona is not provided in the input, score accuracy at 0.5 and say so.
+- Return only the JSON object. No commentary, no preamble.

--- a/survey-cli/survey/reliability/personas_quarantine.py
+++ b/survey-cli/survey/reliability/personas_quarantine.py
@@ -1,0 +1,446 @@
+"""================================================================================
+PERSONAS QUARANTINE — File-based store for drifted-persona isolation (SR-170 PR1)
+================================================================================
+
+MODUL-KONZEPT (SR-170, 2026-05-13)
+-----------------------------------
+
+WARUM ÜBERHAUPT?
+    `trajectory_judge.py` liefert nach jedem Run eine `JudgeScoreCard`
+    mit 4 Scores. Wenn `min(scores) < quarantine_threshold`, sollte die
+    betroffene Persona NICHT für den nächsten Run wiederverwendet
+    werden — sie braucht entweder manuelles Review oder ein Re-Train.
+
+    Dieser Store ist der einfachst-mögliche Mechanismus dafür: eine
+    JSON-Datei pro quarantänisierter Persona, geordnet unter
+    `runs/quarantine/<persona_id>.json`. Beim nächsten Run-Start fragt
+    der Persona-Selector über `is_quarantined(persona_id)` ab und
+    skippt den Eintrag.
+
+WARUM DATEI-BASIERT?
+    • Keine externe Abhängigkeit (SQLite, Redis, Postgres) für eine
+      Operation, die typisch < 100 Einträge produziert pro Tag.
+    • Atomarität via `os.replace()` — POSIX-rename ist auf gleicher
+      FS-Partition atomar, also keine half-written JSONs.
+    • Auditbar: `git diff` der `runs/quarantine/` reicht für ein
+      menschliches Review, kein SQL nötig.
+    • Test-Determinismus: `tmp_path`-Fixture, kein Mock-DB-Tooling.
+
+NICHT-ZIELE
+-----------
+    Dieses Modul macht KEIN:
+      • Persona-Selection-Logic (wo wird die Quarantine konsultiert?
+        → das ist Aufgabe des Caller-Codes, z. B. `persona_picker.py`).
+      • Auto-Release nach Zeit (TTL). `release()` ist immer explizit.
+      • Persona-Definitionen (siehe Brief-Constraint: nur `persona_id:
+        str`-zentriert, keine Persona-Modelle).
+
+PUBLIC API
+----------
+    QuarantineEntry        — frozen dataclass mit Eintrag-Metadaten
+    QuarantineError        — Basisklasse für Fehler
+    PersonaNotQuarantined  — release() auf non-quarantined ID
+    quarantine             — Eintrag anlegen / updaten
+    is_quarantined         — Bool-Check
+    list_active            — alle aktiven Einträge
+    release                — Eintrag schließen (mit Audit-Reason)
+    get                    — einzelnen Eintrag lesen (incl. released)
+
+ADD-HERE-TOO CHECKLIST (when extending this module)
+----------------------------------------------------
+    [ ] New field on QuarantineEntry?       → update to_dict/from_dict
+        AND the JSON schema-version constant AND the migration logic in
+        from_dict for old files.
+    [ ] New error type?                     → also extend tests.
+    [ ] Auto-release / TTL?                 → STOP, requires a separate
+        background job + decision on policy. Open follow-up issue.
+
+Module Status: NEW (SR-170 Phase PR1, 2026-05-13)
+================================================================================
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+
+# ── ERRORS ───────────────────────────────────────────────────────────────────
+
+
+class QuarantineError(Exception):
+    """Base class for all quarantine-store failures."""
+
+
+class PersonaNotQuarantined(QuarantineError):
+    """release() / get() called for a persona_id that has no entry."""
+
+
+# ── SCHEMA VERSION ───────────────────────────────────────────────────────────
+
+
+_SCHEMA_VERSION: int = 1
+"""
+Bump this when QuarantineEntry's on-disk shape changes incompatibly.
+The from_dict() loader keeps backward compatibility via the version
+field on each JSON file.
+"""
+
+
+# ── DATA SHAPE ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class QuarantineEntry:
+    """
+    One quarantine record, on-disk under `<store_root>/<persona_id>.json`.
+
+    Fields:
+        persona_id:        opaque caller-chosen identifier (string).
+        reason:            free-form why-it-was-quarantined.
+        judge_scores:      the JudgeScoreCard.to_dict() that triggered
+                           the quarantine. Optional: empty dict if the
+                           quarantine was manual.
+        quarantined_at:    UNIX epoch seconds (int) when first quarantined.
+        released_at:       UNIX epoch seconds (int) when released, or None
+                           if still active.
+        release_reason:    free-form why-it-was-released, or empty.
+        schema_version:    on-disk schema version, see _SCHEMA_VERSION.
+    """
+
+    persona_id: str
+    reason: str
+    judge_scores: dict[str, Any] = field(default_factory=dict)
+    quarantined_at: int = 0
+    released_at: Optional[int] = None
+    release_reason: str = ""
+    schema_version: int = _SCHEMA_VERSION
+
+    def is_active(self) -> bool:
+        """True iff the entry has not been released yet."""
+        return self.released_at is None
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-safe dict; ordered fields for readable git diffs."""
+        return {
+            "persona_id": self.persona_id,
+            "reason": self.reason,
+            "judge_scores": dict(self.judge_scores),
+            "quarantined_at": self.quarantined_at,
+            "released_at": self.released_at,
+            "release_reason": self.release_reason,
+            "schema_version": self.schema_version,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> QuarantineEntry:
+        """
+        Reconstruct from on-disk JSON. Tolerates older schema versions
+        by filling missing fields with safe defaults.
+        """
+        return cls(
+            persona_id=str(data["persona_id"]),
+            reason=str(data.get("reason", "")),
+            judge_scores=dict(data.get("judge_scores", {})),
+            quarantined_at=int(data.get("quarantined_at", 0)),
+            released_at=(
+                int(data["released_at"]) if data.get("released_at") is not None else None
+            ),
+            release_reason=str(data.get("release_reason", "")),
+            schema_version=int(data.get("schema_version", 0)),
+        )
+
+
+# ── STORE ROOT (DEFAULT) ─────────────────────────────────────────────────────
+
+
+_DEFAULT_STORE_RELPATH: str = "runs/quarantine"
+"""Relative to repo-root / $STEALTH_RUNNER_ROOT / cwd."""
+
+
+def _resolve_store_root(store_root: Optional[Path]) -> Path:
+    """
+    Decide where the quarantine JSONs live.
+
+    Order:
+        1. Explicit `store_root` arg.
+        2. $STEALTH_RUNNER_ROOT env var (joined with default subdir).
+        3. CWD / default subdir.
+
+    Auto-creates the directory.
+    """
+    if store_root is not None:
+        resolved = Path(store_root)
+    else:
+        env_root = os.environ.get("STEALTH_RUNNER_ROOT")
+        base = Path(env_root) if env_root else Path.cwd()
+        resolved = base / _DEFAULT_STORE_RELPATH
+    resolved.mkdir(parents=True, exist_ok=True)
+    return resolved
+
+
+def _entry_path(store_root: Path, persona_id: str) -> Path:
+    """
+    Build the on-disk path for one persona_id.
+
+    Sanitization: replace any character that is not [A-Za-z0-9._-] with
+    '_'. We keep this minimal — the caller controls persona_id and is
+    expected to use opaque tokens, not user input.
+    """
+    safe = "".join(c if (c.isalnum() or c in "._-") else "_" for c in persona_id)
+    if not safe or safe.startswith("."):
+        raise ValueError(
+            f"persona_id sanitizes to empty/hidden filename: {persona_id!r}"
+        )
+    return store_root / f"{safe}.json"
+
+
+# ── ATOMIC WRITE ─────────────────────────────────────────────────────────────
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """
+    Write JSON via `tmp + os.replace()`. On POSIX, replace() is atomic
+    within one filesystem, so a reader either sees the old file or the
+    new file — never a half-written one.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # NamedTemporaryFile in the same directory ensures replace() is
+    # cross-link compatible (same FS partition).
+    fd, tmp_path_str = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False, indent=2, sort_keys=False)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        # Best-effort cleanup; we never want stale .tmp files hanging around.
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        raise
+
+
+# ── PUBLIC API ───────────────────────────────────────────────────────────────
+
+
+def quarantine(
+    persona_id: str,
+    reason: str,
+    judge_scores: Optional[dict[str, Any]] = None,
+    *,
+    store_root: Optional[Path] = None,
+    now: Optional[int] = None,
+) -> QuarantineEntry:
+    """
+    Quarantine a persona, or re-quarantine an already-active one.
+
+    Semantics:
+      • If `persona_id` is not quarantined yet:        create new active entry.
+      • If `persona_id` IS already active:             update reason/scores,
+                                                       keep original
+                                                       quarantined_at.
+      • If `persona_id` was previously released:       create a new active
+                                                       entry, with a fresh
+                                                       quarantined_at (i.e.,
+                                                       the release record is
+                                                       overwritten — caller
+                                                       should grep audit log
+                                                       if the history matters).
+
+    Args:
+        persona_id:    opaque identifier; must sanitize to a non-empty filename.
+        reason:        free-form. Will be persisted verbatim.
+        judge_scores:  optional dict (e.g. JudgeScoreCard.to_dict()).
+        store_root:    optional path override; default = repo-rooted runs/quarantine.
+        now:           optional epoch-seconds injection for test determinism.
+
+    Returns:
+        The QuarantineEntry as written.
+    """
+    root = _resolve_store_root(store_root)
+    path = _entry_path(root, persona_id)
+    timestamp = int(now if now is not None else time.time())
+
+    # If an active entry exists, preserve its `quarantined_at` for audit.
+    quarantined_at = timestamp
+    if path.is_file():
+        try:
+            existing = QuarantineEntry.from_dict(json.loads(path.read_text("utf-8")))
+            if existing.is_active():
+                quarantined_at = existing.quarantined_at or timestamp
+        except (json.JSONDecodeError, KeyError, ValueError):
+            # Corrupt file → overwrite with fresh entry. Don't crash the caller.
+            pass
+
+    entry = QuarantineEntry(
+        persona_id=persona_id,
+        reason=reason,
+        judge_scores=dict(judge_scores or {}),
+        quarantined_at=quarantined_at,
+        released_at=None,
+        release_reason="",
+        schema_version=_SCHEMA_VERSION,
+    )
+    _atomic_write_json(path, entry.to_dict())
+    return entry
+
+
+def is_quarantined(
+    persona_id: str,
+    *,
+    store_root: Optional[Path] = None,
+) -> bool:
+    """
+    True iff there is an active (un-released) quarantine for this persona_id.
+
+    Released entries return False — they are kept on disk for audit but
+    do not block the persona from being re-used.
+    """
+    root = _resolve_store_root(store_root)
+    path = _entry_path(root, persona_id)
+    if not path.is_file():
+        return False
+    try:
+        entry = QuarantineEntry.from_dict(json.loads(path.read_text("utf-8")))
+    except (json.JSONDecodeError, KeyError, ValueError):
+        # Corrupt file → fail-safe: treat as quarantined so the caller
+        # surfaces the corruption instead of silently using the persona.
+        return True
+    return entry.is_active()
+
+
+def list_active(
+    *,
+    store_root: Optional[Path] = None,
+) -> list[QuarantineEntry]:
+    """
+    Return every currently-active quarantine, ordered by quarantined_at ASC.
+
+    Released entries are NOT included. Corrupt files are skipped silently
+    (use `get(persona_id)` for diagnostics on a specific id).
+    """
+    root = _resolve_store_root(store_root)
+    entries: list[QuarantineEntry] = []
+    for path in sorted(root.glob("*.json")):
+        try:
+            entry = QuarantineEntry.from_dict(json.loads(path.read_text("utf-8")))
+        except (json.JSONDecodeError, KeyError, ValueError):
+            continue
+        if entry.is_active():
+            entries.append(entry)
+    entries.sort(key=lambda e: e.quarantined_at)
+    return entries
+
+
+def release(
+    persona_id: str,
+    override_reason: str,
+    *,
+    store_root: Optional[Path] = None,
+    now: Optional[int] = None,
+) -> QuarantineEntry:
+    """
+    Mark an active quarantine as released.
+
+    The on-disk file is REWRITTEN with `released_at` and `release_reason`
+    set; it is NOT deleted, so audit greps still find the history.
+
+    Args:
+        persona_id:       must currently be active.
+        override_reason:  free-form justification, e.g. "false positive,
+                          manual review confirmed persona OK".
+        store_root:       optional override.
+        now:              optional epoch-seconds for test determinism.
+
+    Returns:
+        The QuarantineEntry as written (now in released state).
+
+    Raises:
+        PersonaNotQuarantined: if the persona is not currently quarantined
+                               (either no entry, or entry already released).
+    """
+    root = _resolve_store_root(store_root)
+    path = _entry_path(root, persona_id)
+    if not path.is_file():
+        raise PersonaNotQuarantined(
+            f"persona_id {persona_id!r} has no quarantine entry to release."
+        )
+    try:
+        existing = QuarantineEntry.from_dict(json.loads(path.read_text("utf-8")))
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        raise QuarantineError(
+            f"Quarantine file for {persona_id!r} is corrupt: {exc!s}"
+        ) from exc
+
+    if not existing.is_active():
+        raise PersonaNotQuarantined(
+            f"persona_id {persona_id!r} is already released "
+            f"(at epoch {existing.released_at})."
+        )
+
+    timestamp = int(now if now is not None else time.time())
+    released = QuarantineEntry(
+        persona_id=existing.persona_id,
+        reason=existing.reason,
+        judge_scores=existing.judge_scores,
+        quarantined_at=existing.quarantined_at,
+        released_at=timestamp,
+        release_reason=override_reason,
+        schema_version=_SCHEMA_VERSION,
+    )
+    _atomic_write_json(path, released.to_dict())
+    return released
+
+
+def get(
+    persona_id: str,
+    *,
+    store_root: Optional[Path] = None,
+) -> QuarantineEntry:
+    """
+    Read one entry (active or released) for diagnostics.
+
+    Raises PersonaNotQuarantined if no entry exists at all. Distinct
+    from is_quarantined() which is a fast boolean; this returns the
+    full record incl. history.
+    """
+    root = _resolve_store_root(store_root)
+    path = _entry_path(root, persona_id)
+    if not path.is_file():
+        raise PersonaNotQuarantined(
+            f"persona_id {persona_id!r} has no quarantine entry."
+        )
+    try:
+        return QuarantineEntry.from_dict(json.loads(path.read_text("utf-8")))
+    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+        raise QuarantineError(
+            f"Quarantine file for {persona_id!r} is corrupt: {exc!s}"
+        ) from exc
+
+
+# ── PUBLIC RE-EXPORTS ────────────────────────────────────────────────────────
+
+
+__all__ = [
+    "PersonaNotQuarantined",
+    "QuarantineEntry",
+    "QuarantineError",
+    "get",
+    "is_quarantined",
+    "list_active",
+    "quarantine",
+    "release",
+]

--- a/survey-cli/survey/reliability/trajectory_judge.py
+++ b/survey-cli/survey/reliability/trajectory_judge.py
@@ -1,0 +1,540 @@
+"""================================================================================
+TRAJECTORY JUDGE — LLM-based post-run audit of survey trajectories (SR-170, PR1)
+================================================================================
+
+MODUL-KONZEPT (SR-170, 2026-05-13)
+-----------------------------------
+
+WARUM ÜBERHAUPT?
+    Selbst wenn SR-167 (`verifier.py`) und SR-168 (`attestation.py`) jeder
+    einzelnen Aktion grünes Licht geben, kann eine *gesamte* Survey-
+    Trajektorie trotzdem driften:
+
+      • Persona-Drift: Die Antwort-Sequenz ist intern inkonsistent
+        (z. B. "Alter 23" in Frage 1, später Antwort die nur ab 30
+        plausibel ist).
+      • Compliance-Drift: Der Agent hat Survey-Instruktionen "nahe
+        genug" befolgt, aber nicht wörtlich (z. B. Slider auf 80 statt
+        explizit gefordert "über 75").
+      • Efficiency-Drift: Die Survey wurde abgeschlossen, aber mit
+        3× re-do der gleichen Page → Provider-seitiges Bot-Signal.
+      • Coherence-Drift: Antworten sehen einzeln korrekt aus, aber die
+        Sequenz fühlt sich roboterhaft-monoton an (immer 0,3-Sekunden-
+        Latenz, immer Antwort B beim Coin-Flip).
+
+    Diese vier Failure-Modi sind per Definition NICHT pro-Aktion
+    detektierbar — sie erfordern eine Bewertung der gesamten Trajektorie
+    NACH dem Run.
+
+DIESES MODUL: backend-agnostischer Judge
+----------------------------------------
+    `TrajectoryJudge` nimmt ein `llm_callable` als Konstruktor-Injection.
+    Das macht das Modul:
+      • Sofort unit-testbar (mocked callable, deterministisch)
+      • Provider-unabhängig (OpenAI ist Default, aber jeder String→String-
+        Callable funktioniert — Anthropic, Groq, lokales LLM, …)
+      • Wiederverwendbar in CLI-Modus UND Daemon-Modus
+
+    Mirroring-Pattern: identisch zu `attestation.py`'s `ChannelFn`
+    Protocol-Injection.
+
+FOUR SCORES (CANONICAL)
+-----------------------
+    Jede Trajektorie wird auf vier orthogonalen Dimensionen bewertet,
+    alle als float ∈ [0.0, 1.0] (1.0 = perfekt, 0.0 = totale Drift):
+
+      compliance — Survey-Instruktionen wörtlich befolgt?
+      efficiency — minimaler Step-Count, kein Re-Do?
+      accuracy   — Antworten zur Persona-Definition konsistent?
+      coherence  — natürliche, mensch-ähnliche Antwort-Sequenz?
+
+    Die LLM liefert JSON: `{"compliance": 0.92, "efficiency": 0.78,
+    "accuracy": 0.85, "coherence": 0.90, "rationale": "..."}`. Out-of-
+    range oder fehlende Felder → `JudgeError`.
+
+QUARANTINE-INTEGRATION
+----------------------
+    Wenn `min(scores) < config.quarantine_threshold`, ruft der Caller
+    (PR2 graph-wiring) `personas_quarantine.quarantine(persona_id, ...)`
+    auf. Dieses Modul selbst macht KEINE Side-Effects. Es liefert nur
+    den `JudgeScoreCard`.
+
+LATENCY BUDGET
+--------------
+    Default: 30 s, $0.005 pro Judge-Call (gpt-4o-mini Annahme). Konfigurierbar
+    via `JudgeConfig.max_latency_s`. Der LLM-Call läuft synchron — Judge
+    ist Post-Submit, nicht im Hot-Path.
+
+PUBLIC API
+----------
+    JudgeError           — alle Failure-Modi (parse, range, empty)
+    JudgeScoreCard       — frozen dataclass mit 4 Scores + rationale
+    JudgeConfig          — tuning knobs
+    LLMCallable          — Protocol für injizierbaren LLM-Aufruf
+    TrajectoryJudge      — die Klasse
+    load_default_prompt  — liest prompts/trajectory_audit.txt
+    make_openai_judge    — convenience factory mit OpenAI als Backend
+
+ADD-HERE-TOO CHECKLIST (when extending this module)
+----------------------------------------------------
+    [ ] New score dimension?  → update JudgeScoreCard, prompt, validator,
+        AND test_trajectory_judge.py matrix.
+    [ ] New JudgeError subclass? → also extend the test for parse-failure
+        modes.
+    [ ] New LLM provider? → add factory parallel to make_openai_judge,
+        keep TrajectoryJudge itself provider-agnostic.
+
+Module Status: NEW (SR-170 Phase PR1, 2026-05-13)
+================================================================================
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Optional, Protocol
+
+
+# ── ERRORS ───────────────────────────────────────────────────────────────────
+
+
+class JudgeError(Exception):
+    """
+    Base class for all failures in TrajectoryJudge.
+
+    Subclasses are deliberately small — most call sites just want
+    to catch `JudgeError` and route to a "needs human review" lane.
+    """
+
+
+class JudgeParseError(JudgeError):
+    """LLM response was not parseable as the expected JSON shape."""
+
+
+class JudgeRangeError(JudgeError):
+    """LLM produced a score outside the [0.0, 1.0] range or NaN."""
+
+
+class JudgeEmptyTrajectoryError(JudgeError):
+    """Judge was called with an empty / None trajectory."""
+
+
+# ── DATA SHAPES ──────────────────────────────────────────────────────────────
+
+
+# The four canonical score dimensions. Order is significant — used as the
+# stable serialization order in JSON and as the iteration order in tests.
+SCORE_FIELDS: tuple[str, ...] = ("compliance", "efficiency", "accuracy", "coherence")
+
+
+@dataclass(frozen=True)
+class JudgeScoreCard:
+    """
+    Immutable result of a single Judge call over one trajectory.
+
+    Fields:
+        compliance:    [0.0, 1.0] — Survey-instructions literally followed?
+        efficiency:    [0.0, 1.0] — Minimal step count, no re-do?
+        accuracy:      [0.0, 1.0] — Answers consistent with persona profile?
+        coherence:     [0.0, 1.0] — Natural human-like response sequence?
+        rationale:     Free-form LLM justification, ≤ 500 chars typically.
+        model:         Identifier of the LLM used (for audit).
+        latency_ms:    Wall-clock time for the LLM call.
+        prompt_hash:   First 16 hex chars of sha256(prompt). Lets you
+                       group score-cards by prompt-version without
+                       leaking the prompt itself into logs.
+    """
+
+    compliance: float
+    efficiency: float
+    accuracy: float
+    coherence: float
+    rationale: str = ""
+    model: str = ""
+    latency_ms: int = 0
+    prompt_hash: str = ""
+
+    def min_score(self) -> float:
+        """Return the lowest of the four scores — used for quarantine triggers."""
+        return min(self.compliance, self.efficiency, self.accuracy, self.coherence)
+
+    def mean_score(self) -> float:
+        """Return the arithmetic mean of the four scores."""
+        return (self.compliance + self.efficiency + self.accuracy + self.coherence) / 4.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-safe representation for log/quarantine-store persistence."""
+        return {
+            "compliance": self.compliance,
+            "efficiency": self.efficiency,
+            "accuracy": self.accuracy,
+            "coherence": self.coherence,
+            "rationale": self.rationale,
+            "model": self.model,
+            "latency_ms": self.latency_ms,
+            "prompt_hash": self.prompt_hash,
+        }
+
+
+# ── INJECTED LLM CONTRACT ────────────────────────────────────────────────────
+
+
+class LLMCallable(Protocol):
+    """
+    A judge backend is any callable that takes one prompt string and
+    returns one response string.
+
+    The prompt will be the fully-rendered audit prompt (system + user
+    parts joined by Judge.build_prompt()). The response is expected to
+    be JSON parseable into the 4-score schema; everything else raises
+    `JudgeParseError`.
+
+    Pattern: keep the backend dumb. All retry/backoff/cost logic lives
+    in the backend implementation, NOT in TrajectoryJudge.
+
+        def my_backend(prompt: str) -> str:
+            response = my_llm_sdk.complete(prompt, max_tokens=400)
+            return response.text
+    """
+
+    def __call__(self, prompt: str) -> str: ...
+
+
+# ── CONFIG ───────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class JudgeConfig:
+    """
+    Tuning knobs for TrajectoryJudge.
+
+    Defaults are tuned for gpt-4o-mini-class models over typical survey
+    trajectories (5–40 steps, ~2 kB serialized).
+    """
+
+    quarantine_threshold: float = 0.55
+    """
+    Suggested cutoff for the *caller* — if min(scores) < this, the
+    caller should quarantine the persona. The Judge itself does NOT
+    act on this; it only reports.
+    """
+
+    max_latency_s: float = 30.0
+    """Soft budget. Exceeded → caller's problem; Judge does not enforce."""
+
+    max_rationale_chars: int = 1000
+    """Truncate rationale to this many characters for log-friendliness."""
+
+    require_rationale: bool = True
+    """If True and the LLM omits 'rationale', raise JudgeParseError."""
+
+
+# ── PROMPT LOADING ───────────────────────────────────────────────────────────
+
+
+_DEFAULT_PROMPT_RELPATH: str = "prompts/trajectory_audit.txt"
+"""
+Relative to repo root. The library does NOT auto-load this — callers
+must explicitly pass the prompt string into the constructor, OR call
+`load_default_prompt()` to fetch it.
+
+Why this separation: keeps the library filesystem-coupling-free, which
+makes tests deterministic (they inject a fixed prompt string).
+"""
+
+
+def load_default_prompt(base_dir: Optional[Path] = None) -> str:
+    """
+    Load the canonical audit prompt from disk.
+
+    Search order:
+        1. Explicit base_dir argument (if provided).
+        2. $STEALTH_RUNNER_ROOT env var (if set).
+        3. Current working directory.
+
+    Args:
+        base_dir: Optional explicit repo root. If None, auto-detected.
+
+    Returns:
+        The prompt as a string.
+
+    Raises:
+        FileNotFoundError: prompt file does not exist at the resolved path.
+    """
+    if base_dir is None:
+        env_root = os.environ.get("STEALTH_RUNNER_ROOT")
+        base_dir = Path(env_root) if env_root else Path.cwd()
+    prompt_path = base_dir / _DEFAULT_PROMPT_RELPATH
+    if not prompt_path.is_file():
+        raise FileNotFoundError(
+            f"Default audit prompt not found at {prompt_path}. "
+            f"Either pass `prompt=` explicitly to TrajectoryJudge, "
+            f"or set $STEALTH_RUNNER_ROOT to the repo root."
+        )
+    return prompt_path.read_text(encoding="utf-8")
+
+
+# ── CORE: TrajectoryJudge ────────────────────────────────────────────────────
+
+
+@dataclass
+class TrajectoryJudge:
+    """
+    Backend-agnostic LLM judge over a completed survey trajectory.
+
+    Construction (typical):
+
+        judge = TrajectoryJudge(
+            llm_callable=my_backend,
+            prompt=load_default_prompt(),
+            config=JudgeConfig(),
+        )
+
+    Or for production with OpenAI:
+
+        judge = make_openai_judge(model="gpt-4o-mini")
+
+    Usage:
+
+        scorecard = judge.audit(trajectory=[...])
+        if scorecard.min_score() < judge.config.quarantine_threshold:
+            personas_quarantine.quarantine(persona_id, ...)
+
+    Thread-safety: instances are stateless after construction. The
+    `llm_callable` it wraps must be safe to call concurrently if the
+    Judge is shared across threads.
+    """
+
+    llm_callable: LLMCallable
+    prompt: str
+    config: JudgeConfig = field(default_factory=JudgeConfig)
+    model_name: str = "unknown"
+    """Free-form identifier the factory sets ('gpt-4o-mini', 'mock', etc.)."""
+
+    def __post_init__(self) -> None:
+        if not self.prompt or not self.prompt.strip():
+            raise ValueError("TrajectoryJudge requires a non-empty prompt string.")
+
+    # ── PUBLIC ENTRY POINT ───────────────────────────────────────────────
+
+    def audit(self, trajectory: list[dict[str, Any]]) -> JudgeScoreCard:
+        """
+        Score one trajectory along the four canonical dimensions.
+
+        Args:
+            trajectory: ordered list of step records. Each step is a
+                        free-form dict; the prompt template renders them
+                        as JSON. Empty list → JudgeEmptyTrajectoryError.
+
+        Returns:
+            JudgeScoreCard with 4 scores + rationale + audit metadata.
+
+        Raises:
+            JudgeEmptyTrajectoryError: trajectory is empty or None.
+            JudgeParseError:           LLM response could not be parsed
+                                       into the 4-score schema.
+            JudgeRangeError:           Any score outside [0.0, 1.0] or NaN.
+        """
+        if not trajectory:
+            raise JudgeEmptyTrajectoryError(
+                "audit() called with empty trajectory — refusing to score nothing."
+            )
+
+        rendered = self._render_prompt(trajectory)
+        t_start = time.perf_counter()
+        raw_response = self.llm_callable(rendered)
+        latency_ms = int((time.perf_counter() - t_start) * 1000)
+
+        parsed = self._parse_response(raw_response)
+        self._validate_scores(parsed)
+
+        rationale = str(parsed.get("rationale", ""))[: self.config.max_rationale_chars]
+
+        return JudgeScoreCard(
+            compliance=float(parsed["compliance"]),
+            efficiency=float(parsed["efficiency"]),
+            accuracy=float(parsed["accuracy"]),
+            coherence=float(parsed["coherence"]),
+            rationale=rationale,
+            model=self.model_name,
+            latency_ms=latency_ms,
+            prompt_hash=self._prompt_hash(),
+        )
+
+    # ── INTERNAL HELPERS ─────────────────────────────────────────────────
+
+    def _render_prompt(self, trajectory: list[dict[str, Any]]) -> str:
+        """
+        Combine the system prompt with the trajectory payload.
+
+        We use a deliberately simple two-section layout instead of
+        f-string templating, because the audit prompt may contain
+        curly braces in examples. The LLM sees:
+
+            <system prompt>
+            ---
+            TRAJECTORY (JSON):
+            [...]
+        """
+        payload = json.dumps(trajectory, ensure_ascii=False, indent=2)
+        return f"{self.prompt}\n\n---\nTRAJECTORY (JSON):\n{payload}\n"
+
+    def _parse_response(self, raw: str) -> dict[str, Any]:
+        """
+        Extract a 4-score JSON object from the raw LLM response.
+
+        Tolerant of:
+          - leading/trailing whitespace
+          - markdown code fences (```json ... ```)
+          - trailing chatter after the JSON block
+
+        Intolerant of:
+          - missing required score fields
+          - non-numeric score values
+          - missing rationale (if config.require_rationale)
+        """
+        cleaned = raw.strip()
+        # Strip a single leading markdown fence, if present.
+        if cleaned.startswith("```"):
+            # Drop the first line (```json or ```), and try to find the closing ```.
+            first_nl = cleaned.find("\n")
+            cleaned = cleaned[first_nl + 1 :] if first_nl != -1 else cleaned[3:]
+            if "```" in cleaned:
+                cleaned = cleaned[: cleaned.rfind("```")]
+            cleaned = cleaned.strip()
+
+        try:
+            parsed = json.loads(cleaned)
+        except json.JSONDecodeError as exc:
+            raise JudgeParseError(
+                f"LLM response is not valid JSON: {exc.msg} "
+                f"(snippet: {cleaned[:120]!r})"
+            ) from exc
+
+        if not isinstance(parsed, dict):
+            raise JudgeParseError(
+                f"LLM response is JSON but not an object (got {type(parsed).__name__})."
+            )
+
+        for field_name in SCORE_FIELDS:
+            if field_name not in parsed:
+                raise JudgeParseError(
+                    f"LLM response missing required score field {field_name!r}. "
+                    f"Got keys: {sorted(parsed.keys())}"
+                )
+
+        if self.config.require_rationale and "rationale" not in parsed:
+            raise JudgeParseError(
+                "LLM response missing required 'rationale' field "
+                "(set config.require_rationale=False to allow this)."
+            )
+
+        return parsed
+
+    def _validate_scores(self, parsed: dict[str, Any]) -> None:
+        """
+        Range-check each score field. Floats only, finite only, [0.0, 1.0].
+        """
+        for field_name in SCORE_FIELDS:
+            value = parsed[field_name]
+            try:
+                fvalue = float(value)
+            except (TypeError, ValueError) as exc:
+                raise JudgeRangeError(
+                    f"Score {field_name!r} is not numeric: {value!r}"
+                ) from exc
+            # NaN check (NaN != NaN).
+            if fvalue != fvalue:
+                raise JudgeRangeError(f"Score {field_name!r} is NaN.")
+            if fvalue < 0.0 or fvalue > 1.0:
+                raise JudgeRangeError(
+                    f"Score {field_name!r} = {fvalue} out of range [0.0, 1.0]."
+                )
+            parsed[field_name] = fvalue
+
+    def _prompt_hash(self) -> str:
+        """Stable short hash for audit-grouping by prompt version."""
+        import hashlib
+
+        return hashlib.sha256(self.prompt.encode("utf-8")).hexdigest()[:16]
+
+
+# ── CONVENIENCE FACTORY: OPENAI BACKEND ──────────────────────────────────────
+
+
+def make_openai_judge(
+    model: str = "gpt-4o-mini",
+    prompt: Optional[str] = None,
+    config: Optional[JudgeConfig] = None,
+    temperature: float = 0.0,
+    max_tokens: int = 400,
+    api_key: Optional[str] = None,
+) -> TrajectoryJudge:
+    """
+    Production factory: wires `openai>=1.0` as the LLM backend.
+
+    The OpenAI client is constructed lazily inside the callable so that
+    importing this module does NOT require OPENAI_API_KEY to be set —
+    which matters for unit tests that import but never call the factory.
+
+    Args:
+        model:         OpenAI chat-completion model id.
+        prompt:        Audit prompt text. If None, loads via load_default_prompt().
+        config:        JudgeConfig override.
+        temperature:   0.0 for deterministic scoring (recommended).
+        max_tokens:    cap on response tokens; 400 is enough for 4 scores
+                       + ~300 chars rationale.
+        api_key:       optional explicit key; else uses $OPENAI_API_KEY.
+
+    Returns:
+        A wired TrajectoryJudge ready to .audit(...).
+    """
+    if prompt is None:
+        prompt = load_default_prompt()
+
+    def _openai_call(rendered_prompt: str) -> str:
+        # Lazy import so that this module is importable without `openai` installed
+        # in environments that only use mock callables (e.g. CI unit tests).
+        from openai import OpenAI
+
+        client = OpenAI(api_key=api_key) if api_key else OpenAI()
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": rendered_prompt}],
+            temperature=temperature,
+            max_tokens=max_tokens,
+            response_format={"type": "json_object"},
+        )
+        choice = response.choices[0]
+        content = choice.message.content
+        if content is None:
+            raise JudgeParseError("OpenAI returned message.content=None.")
+        return content
+
+    return TrajectoryJudge(
+        llm_callable=_openai_call,
+        prompt=prompt,
+        config=config or JudgeConfig(),
+        model_name=model,
+    )
+
+
+# ── PUBLIC RE-EXPORTS ────────────────────────────────────────────────────────
+
+
+__all__ = [
+    "SCORE_FIELDS",
+    "JudgeConfig",
+    "JudgeEmptyTrajectoryError",
+    "JudgeError",
+    "JudgeParseError",
+    "JudgeRangeError",
+    "JudgeScoreCard",
+    "LLMCallable",
+    "TrajectoryJudge",
+    "load_default_prompt",
+    "make_openai_judge",
+]

--- a/survey-cli/tests/test_trajectory_judge.py
+++ b/survey-cli/tests/test_trajectory_judge.py
@@ -1,0 +1,351 @@
+"""
+test_trajectory_judge.py — Unit tests for SR-170 PR1.
+
+Covers:
+  - survey.reliability.trajectory_judge:    10 tests
+  - survey.reliability.personas_quarantine:  9 tests
+
+All LLM calls are mocked via a plain Callable[[str], str]. No `openai`
+package is required at test time. All filesystem operations use the
+pytest `tmp_path` fixture for full determinism.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from survey.reliability.personas_quarantine import (
+    PersonaNotQuarantined,
+    QuarantineEntry,
+    is_quarantined,
+    list_active,
+    quarantine,
+    release,
+)
+from survey.reliability.personas_quarantine import (
+    get as quarantine_get,
+)
+from survey.reliability.trajectory_judge import (
+    SCORE_FIELDS,
+    JudgeConfig,
+    JudgeEmptyTrajectoryError,
+    JudgeParseError,
+    JudgeRangeError,
+    JudgeScoreCard,
+    TrajectoryJudge,
+)
+
+
+# ── HELPERS ──────────────────────────────────────────────────────────────────
+
+
+_FAKE_PROMPT = "AUDIT PROMPT — do the thing."
+
+_GOOD_TRAJECTORY: list[dict[str, Any]] = [
+    {"step": 0, "page": "q1", "answer": "yes"},
+    {"step": 1, "page": "q2", "answer": "blue"},
+    {"step": 2, "page": "q3", "answer": "agree"},
+]
+
+
+def _make_judge(response: str, *, config: JudgeConfig | None = None) -> TrajectoryJudge:
+    """Build a judge that always returns the given fixed response string."""
+    return TrajectoryJudge(
+        llm_callable=lambda _prompt: response,
+        prompt=_FAKE_PROMPT,
+        config=config or JudgeConfig(),
+        model_name="mock",
+    )
+
+
+def _good_response(
+    compliance: float = 0.9,
+    efficiency: float = 0.8,
+    accuracy: float = 0.85,
+    coherence: float = 0.95,
+    rationale: str = "looks fine.",
+) -> str:
+    return json.dumps(
+        {
+            "compliance": compliance,
+            "efficiency": efficiency,
+            "accuracy": accuracy,
+            "coherence": coherence,
+            "rationale": rationale,
+        }
+    )
+
+
+# =============================================================================
+# TRAJECTORY JUDGE TESTS
+# =============================================================================
+
+
+def test_audit_returns_scorecard_with_four_fields() -> None:
+    """audit() must return a JudgeScoreCard with all four canonical scores."""
+    judge = _make_judge(_good_response())
+    card = judge.audit(_GOOD_TRAJECTORY)
+    assert isinstance(card, JudgeScoreCard)
+    for f in SCORE_FIELDS:
+        assert hasattr(card, f), f"missing score field {f}"
+    assert card.compliance == 0.9
+    assert card.efficiency == 0.8
+    assert card.accuracy == 0.85
+    assert card.coherence == 0.95
+    assert card.rationale == "looks fine."
+
+
+def test_audit_parses_plain_json_response() -> None:
+    """A bare JSON object (no markdown) must parse cleanly."""
+    judge = _make_judge(
+        '{"compliance": 0.5, "efficiency": 0.6, "accuracy": 0.7, "coherence": 0.8, "rationale": "ok"}'
+    )
+    card = judge.audit(_GOOD_TRAJECTORY)
+    assert card.compliance == 0.5
+    assert card.coherence == 0.8
+
+
+def test_audit_strips_markdown_code_fence() -> None:
+    """LLMs love wrapping JSON in ```json fences; we must tolerate that."""
+    wrapped = (
+        "```json\n"
+        '{"compliance": 0.4, "efficiency": 0.4, "accuracy": 0.4, '
+        '"coherence": 0.4, "rationale": "wrapped"}\n'
+        "```"
+    )
+    judge = _make_judge(wrapped)
+    card = judge.audit(_GOOD_TRAJECTORY)
+    assert card.compliance == 0.4
+    assert card.rationale == "wrapped"
+
+
+def test_audit_raises_on_invalid_json() -> None:
+    """Garbage from the LLM must raise JudgeParseError, not crash."""
+    judge = _make_judge("definitely not json {{{")
+    with pytest.raises(JudgeParseError):
+        judge.audit(_GOOD_TRAJECTORY)
+
+
+def test_audit_raises_on_missing_score_field() -> None:
+    """If the LLM omits one of the 4 required score fields → JudgeParseError."""
+    judge = _make_judge(
+        '{"compliance": 0.9, "efficiency": 0.9, "accuracy": 0.9, "rationale": "missing coherence"}'
+    )
+    with pytest.raises(JudgeParseError, match="coherence"):
+        judge.audit(_GOOD_TRAJECTORY)
+
+
+def test_audit_raises_on_out_of_range_score() -> None:
+    """Score outside [0.0, 1.0] → JudgeRangeError."""
+    judge = _make_judge(_good_response(compliance=1.5))
+    with pytest.raises(JudgeRangeError, match="compliance"):
+        judge.audit(_GOOD_TRAJECTORY)
+
+
+def test_audit_raises_on_non_numeric_score() -> None:
+    """Non-numeric score (e.g. string label) → JudgeRangeError."""
+    judge = _make_judge(
+        '{"compliance": "high", "efficiency": 0.8, "accuracy": 0.8, '
+        '"coherence": 0.8, "rationale": "bad"}'
+    )
+    with pytest.raises(JudgeRangeError, match="compliance"):
+        judge.audit(_GOOD_TRAJECTORY)
+
+
+def test_audit_raises_on_nan_score() -> None:
+    """NaN must be rejected even though it's technically a float."""
+    judge = _make_judge(
+        # JSON doesn't natively support NaN; we synthesize a value the parser
+        # turns into nan via "Infinity" trick — but standard json rejects that.
+        # Easier route: feed a parseable-but-NaN value through a custom path.
+        # Use Python json with allow_nan=True roundtrip is unavailable in pure
+        # JSON. Instead, mock the response to be JSON5-style "NaN" which the
+        # stdlib's json.loads can actually parse — it accepts "NaN" non-spec.
+        '{"compliance": NaN, "efficiency": 0.8, "accuracy": 0.8, '
+        '"coherence": 0.8, "rationale": "bad"}'
+    )
+    with pytest.raises(JudgeRangeError, match="NaN"):
+        judge.audit(_GOOD_TRAJECTORY)
+
+
+def test_audit_raises_on_empty_trajectory() -> None:
+    """Empty list must raise before any LLM call."""
+    judge = _make_judge(_good_response())
+    with pytest.raises(JudgeEmptyTrajectoryError):
+        judge.audit([])
+
+
+def test_audit_records_latency_and_prompt_hash() -> None:
+    """ScoreCard must carry latency_ms ≥ 0 and a non-empty prompt_hash."""
+    judge = _make_judge(_good_response())
+    card = judge.audit(_GOOD_TRAJECTORY)
+    assert card.latency_ms >= 0
+    assert card.latency_ms < 1000  # mock callable is instant
+    assert len(card.prompt_hash) == 16
+    assert all(c in "0123456789abcdef" for c in card.prompt_hash)
+    assert card.model == "mock"
+
+
+def test_scorecard_min_mean_and_frozen() -> None:
+    """min_score()/mean_score() helpers + frozen-dataclass invariant."""
+    card = JudgeScoreCard(
+        compliance=0.4, efficiency=0.6, accuracy=0.8, coherence=1.0, rationale=""
+    )
+    assert card.min_score() == pytest.approx(0.4)
+    assert card.mean_score() == pytest.approx(0.7)
+    # Frozen → assignment must fail. dataclasses raises FrozenInstanceError
+    # which is a subclass of AttributeError, so catching either is fine.
+    with pytest.raises((AttributeError, TypeError, Exception)):
+        card.compliance = 0.0  # type: ignore[misc]
+
+
+def test_judge_rejects_empty_prompt_in_constructor() -> None:
+    """Constructing with whitespace-only prompt must raise."""
+    with pytest.raises(ValueError):
+        TrajectoryJudge(
+            llm_callable=lambda _p: _good_response(),
+            prompt="   \n  ",
+        )
+
+
+def test_require_rationale_can_be_disabled() -> None:
+    """With require_rationale=False, omitting the rationale must NOT raise."""
+    cfg = JudgeConfig(require_rationale=False)
+    judge = _make_judge(
+        '{"compliance": 0.7, "efficiency": 0.7, "accuracy": 0.7, "coherence": 0.7}',
+        config=cfg,
+    )
+    card = judge.audit(_GOOD_TRAJECTORY)
+    assert card.rationale == ""
+
+
+# =============================================================================
+# PERSONA QUARANTINE TESTS
+# =============================================================================
+
+
+def test_quarantine_creates_entry_file(tmp_path: Path) -> None:
+    """quarantine() must produce a readable JSON at <root>/<id>.json."""
+    entry = quarantine(
+        "p-001",
+        reason="judge below threshold",
+        judge_scores={"compliance": 0.2},
+        store_root=tmp_path,
+        now=1_700_000_000,
+    )
+    target = tmp_path / "p-001.json"
+    assert target.is_file()
+    on_disk = json.loads(target.read_text("utf-8"))
+    assert on_disk["persona_id"] == "p-001"
+    assert on_disk["reason"] == "judge below threshold"
+    assert on_disk["quarantined_at"] == 1_700_000_000
+    assert on_disk["released_at"] is None
+    assert entry.is_active()
+
+
+def test_is_quarantined_lifecycle(tmp_path: Path) -> None:
+    """False → quarantine → True → release → False."""
+    assert is_quarantined("p-002", store_root=tmp_path) is False
+    quarantine("p-002", reason="drift", store_root=tmp_path, now=10)
+    assert is_quarantined("p-002", store_root=tmp_path) is True
+    release("p-002", override_reason="manual review ok", store_root=tmp_path, now=20)
+    assert is_quarantined("p-002", store_root=tmp_path) is False
+
+
+def test_list_active_sorted_by_quarantined_at(tmp_path: Path) -> None:
+    """list_active() must return entries ordered by quarantined_at ASC."""
+    quarantine("p-late", reason="r", store_root=tmp_path, now=300)
+    quarantine("p-early", reason="r", store_root=tmp_path, now=100)
+    quarantine("p-mid", reason="r", store_root=tmp_path, now=200)
+    actives = list_active(store_root=tmp_path)
+    assert [e.persona_id for e in actives] == ["p-early", "p-mid", "p-late"]
+    # And after releasing one, it must vanish from the list.
+    release("p-mid", override_reason="ok", store_root=tmp_path, now=400)
+    actives = list_active(store_root=tmp_path)
+    assert [e.persona_id for e in actives] == ["p-early", "p-late"]
+
+
+def test_release_raises_for_non_quarantined(tmp_path: Path) -> None:
+    """release() on an id that was never quarantined → PersonaNotQuarantined."""
+    with pytest.raises(PersonaNotQuarantined):
+        release("never-existed", override_reason="x", store_root=tmp_path)
+
+
+def test_release_raises_when_already_released(tmp_path: Path) -> None:
+    """release() twice → second call raises PersonaNotQuarantined."""
+    quarantine("p-twice", reason="r", store_root=tmp_path, now=10)
+    release("p-twice", override_reason="first", store_root=tmp_path, now=20)
+    with pytest.raises(PersonaNotQuarantined):
+        release("p-twice", override_reason="second", store_root=tmp_path, now=30)
+
+
+def test_quarantine_idempotent_preserves_original_timestamp(tmp_path: Path) -> None:
+    """
+    Re-quarantining an already-active id must keep the original
+    quarantined_at (so we don't reset audit history when caller updates
+    the reason).
+    """
+    quarantine("p-rq", reason="first", store_root=tmp_path, now=1000)
+    second = quarantine(
+        "p-rq",
+        reason="updated reason",
+        judge_scores={"min": 0.1},
+        store_root=tmp_path,
+        now=9999,
+    )
+    assert second.quarantined_at == 1000  # NOT 9999
+    assert second.reason == "updated reason"
+    assert second.judge_scores == {"min": 0.1}
+
+
+def test_entry_json_roundtrip_preserves_all_fields(tmp_path: Path) -> None:
+    """Quarantine → release → re-read must preserve every field byte-faithfully."""
+    quarantine(
+        "p-rt",
+        reason="r-reason",
+        judge_scores={"compliance": 0.3, "rationale": "low"},
+        store_root=tmp_path,
+        now=42,
+    )
+    release("p-rt", override_reason="manual", store_root=tmp_path, now=99)
+    got = quarantine_get("p-rt", store_root=tmp_path)
+    assert got.persona_id == "p-rt"
+    assert got.reason == "r-reason"
+    assert got.judge_scores == {"compliance": 0.3, "rationale": "low"}
+    assert got.quarantined_at == 42
+    assert got.released_at == 99
+    assert got.release_reason == "manual"
+    assert got.schema_version >= 1
+
+
+def test_quarantine_entry_is_frozen() -> None:
+    """QuarantineEntry must be immutable to prevent post-hoc audit tampering."""
+    e = QuarantineEntry(persona_id="x", reason="y", quarantined_at=1)
+    with pytest.raises((AttributeError, TypeError, Exception)):
+        e.reason = "tampered"  # type: ignore[misc]
+
+
+def test_persona_id_with_unsafe_chars_is_sanitized(tmp_path: Path) -> None:
+    """
+    persona_ids containing '/', whitespace, or '..' must NOT escape the
+    store_root. The sanitizer replaces those chars with '_'.
+    """
+    entry = quarantine(
+        "../weird id/with slashes",
+        reason="r",
+        store_root=tmp_path,
+        now=1,
+    )
+    # The file must live inside tmp_path (not escape it).
+    files = list(tmp_path.glob("*.json"))
+    assert len(files) == 1
+    assert files[0].parent == tmp_path
+    # And the entry can be looked up by the same (un-sanitized) id, because
+    # the sanitization is deterministic.
+    assert is_quarantined("../weird id/with slashes", store_root=tmp_path) is True
+    assert entry.persona_id == "../weird id/with slashes"  # stored verbatim in JSON


### PR DESCRIPTION
## SR-170 — Trajectory Judge (PR1 of 2)

**Part of #170 — requires PR2 for closure.**

Owner of PR2 (graph + reward-normalizer wiring) is TBD; see [#170 comment](https://github.com/SIN-CLIs/stealth-runner/issues/170#issuecomment-4439564686) for the split plan.

---

### What this PR ships

A backend-agnostic LLM judge for completed survey trajectories, plus a file-based quarantine store for drifted personas. **Inert** — nothing in this PR auto-wires into the survey graph or the reward path. Calling code is added in PR2.

| File | Purpose |
|---|---|
| `survey-cli/survey/reliability/trajectory_judge.py` | `TrajectoryJudge`, `JudgeScoreCard`, `JudgeConfig`, `make_openai_judge()` factory |
| `survey-cli/survey/reliability/personas_quarantine.py` | `quarantine() / is_quarantined() / list_active() / release() / get()` over JSON files |
| `prompts/trajectory_audit.txt` | Canonical audit prompt, loaded via `load_default_prompt()` |
| `survey-cli/tests/test_trajectory_judge.py` | 19 deterministic tests (mock LLM callable + `tmp_path` for quarantine) |

### Design highlights

- **Backend-agnosticism mirrors `attestation.py`'s `ChannelFn` Protocol injection.** `TrajectoryJudge` takes `llm_callable: Callable[[str], str]`. Tests use `lambda _: '{"compliance":0.9, ...}'`; production uses `make_openai_judge(model="gpt-4o-mini")`.
- **Four canonical scores** — `compliance`, `efficiency`, `accuracy`, `coherence` ∈ [0.0, 1.0]. Drift-relevant dimensions drawn from #170 body.
- **Quarantine is filesystem-only.** Atomic writes via `tmp + os.replace()`. No SQLite, no Redis, no daemon. Store root defaults to `runs/quarantine/` (runtime-only, already in `.gitignore`) but is explicitly overridable for tests.
- **No `Persona` model import.** Quarantine is `persona_id: str`-centric, per brief constraint and per repo state (no `Persona` class exists yet).
- **`openai>=1.0` already in `pyproject.toml`.** No dependency add.
- **No NIM code.** The NIM-primary/secondary references in the #170 issue body are vaporware (zero code hits across the codebase — confirmed via #218 audit). The Issue-body should be edited to drop those references on merge.
- **No `__init__.py` edit** for `survey/reliability/` — same pattern as `attestation.py`, `stability.py`, `visual_hash.py`. Callers import directly.

### Explicitly NOT in this PR (deferred to PR2)

- Any edit to `survey/daemon/survey_agent_graph.py`
- Any edit to `survey/reward/reward_normalizer.py` (no helper function either)
- Re-training-export pipeline
- Auto-activation hooks

### Doctrine compliance (AGENTS.md)

- No `time.sleep` (we use `time.perf_counter` for latency only)
- No XPath, no `eval`-strings
- No browser/driver deps
- All public surfaces type-annotated, frozen dataclasses for result records
- ADD-HERE-TOO checklist at the top of both new modules

### Test surface (19 tests)

**Trajectory Judge (12):**
1. `test_audit_returns_scorecard_with_four_fields`
2. `test_audit_parses_plain_json_response`
3. `test_audit_strips_markdown_code_fence`
4. `test_audit_raises_on_invalid_json`
5. `test_audit_raises_on_missing_score_field`
6. `test_audit_raises_on_out_of_range_score`
7. `test_audit_raises_on_non_numeric_score`
8. `test_audit_raises_on_nan_score`
9. `test_audit_raises_on_empty_trajectory`
10. `test_audit_records_latency_and_prompt_hash`
11. `test_scorecard_min_mean_and_frozen`
12. `test_judge_rejects_empty_prompt_in_constructor`
13. `test_require_rationale_can_be_disabled`

**Persona Quarantine (8):**
1. `test_quarantine_creates_entry_file`
2. `test_is_quarantined_lifecycle`
3. `test_list_active_sorted_by_quarantined_at`
4. `test_release_raises_for_non_quarantined`
5. `test_release_raises_when_already_released`
6. `test_quarantine_idempotent_preserves_original_timestamp`
7. `test_entry_json_roundtrip_preserves_all_fields`
8. `test_quarantine_entry_is_frozen`
9. `test_persona_id_with_unsafe_chars_is_sanitized`

All tests run without `openai` SDK actually installed at test time (the OpenAI import in `make_openai_judge` is lazy).

### Follow-up

- **PR2:** wire `TrajectoryJudge` into `survey_agent_graph.py` as a post-submit node, and route `min_score() < threshold` to `personas_quarantine.quarantine(...)`. Add a single function in `reward_normalizer.py` to weight the four scores into the existing reward signal.
- **Out-of-scope but worth filing:** TTL/auto-release policy for quarantine entries; currently every release is manual.

---

_Built by Agent v0 (Critic chair) over the GitHub REST API — no local clone. Token will be rotated after merge per ops convention._
